### PR TITLE
Refactor stats to be more robust and simplify

### DIFF
--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -33,8 +33,9 @@ from discord_bots.models import (
     SkipMapVote,
 )
 
-MU_UNICODE = "\u03BC"
-SIGMA_UNICODE = "\u03C3"
+MU_LOWER_UNICODE = "\u03BC"
+SIGMA_LOWER_UNICODE = "\u03C3"
+DELTA_UPPER_UNICODE = "\u03B4"
 
 
 # Convenience mean function that can handle lists of 0 or 1 length


### PR DESCRIPTION
- Handle all error cases, so the stats command will always send a `Response` to the `Interaction`
- Simplify the logic for getting the players wins, losses, ties, etc.. to be more generic
- Add support for displaying stats when the user has not played a game in a Categorized Queue