### PR TITLE
Fixed prediction refunding & timeout

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1280,7 +1280,7 @@ async def ban(ctx: Context, member: Member):
 async def cancelgame(interaction: Interaction, game_id: str):
     if config.ECONOMY_ENABLED:
         try:
-            await EconomyCommands.cancel_predictions(interaction, game_id)
+            await EconomyCommands.cancel_predictions(None, game_id)
         except ValueError as ve:
             #Raised if there are no predictions on this game
             await interaction.channel.send(
@@ -1292,7 +1292,7 @@ async def cancelgame(interaction: Interaction, game_id: str):
         except Exception as e:
             await interaction.channel.send(
                 embed=Embed(
-                    description="Predictions failed to refund",
+                    description=f"Predictions failed to refund: {e}",
                     colour=Colour.red()
                 )           
             )
@@ -3421,6 +3421,33 @@ async def _rebalance_game(
     )
     session.commit()
 
+    if config.ECONOMY_ENABLED:
+        try:
+            await EconomyCommands.cancel_predictions(None, game.id)
+        except ValueError as ve:
+            #Raised if there are no predictions on this game
+            await send_message(
+                message.channel,
+                content="",
+                embed_description="No predictions to be refunded",
+                colour=Colour.blue()
+            )
+        except Exception as e:
+            print(f"{e}")
+            await send_message(
+                message.channel,
+                content="",
+                embed_description="Predictions failed to refund",
+                colour=Colour.blue()
+            )
+        else:
+            await send_message(
+                message.channel,
+                content="",
+                embed_description="Predictions refunded",
+                colour=Colour.blue()
+            )
+
     if config.ENABLE_VOICE_MOVE:
         if queue.move_enabled:
             await _movegameplayers(short_game_id, None, message.guild)
@@ -3429,7 +3456,7 @@ async def _rebalance_game(
                 embed_description=f"Players moved to new team voice channels for game {short_game_id}",
                 colour=Colour.green(),
             )
-
+    
     pass
 
 

--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -449,7 +449,6 @@ async def prediction_task():
             )
             .all()
         )
-    session.close()
     try:
         await EconomyCommands.update_embeds(None, in_progress_games)
     except Exception as e:
@@ -458,7 +457,9 @@ async def prediction_task():
         # Cleanly cancel & restart task to resolve
         logging.warn(e)
         logging.info("prediction_task restarting...")
+        session.close()
         prediction_task.cancel()
         prediction_task.restart()
     
     await EconomyCommands.close_predictions(None, in_progress_games=in_progress_games)
+    session.close()


### PR DESCRIPTION
Fixed a couple of immediate errors with predictions no timing out, or refunding correctly on cancel game.

Need to cater for Delete Game, but will do in separate branch so as to push this through quicker.

Prediction embeds also not updating after a rebalance (after refund).