### PR TITLE
fix: setgamecode interaction response timing out, log all errors

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1287,25 +1287,21 @@ async def cancelgame(interaction: Interaction, game_id: str):
                 embed=Embed(
                     description="No predictions to be refunded",
                     colour=Colour.blue()
-                )           
+                )
             )
         except Exception as e:
             await interaction.channel.send(
                 embed=Embed(
                     description=f"Predictions failed to refund: {e}",
                     colour=Colour.red()
-                )           
+                )
             )
         else:
             await interaction.channel.send(
-                embed=Embed(
-                    description="Predictions refunded",
-                    colour=Colour.blue()
-                )           
+                embed=Embed(description="Predictions refunded", colour=Colour.blue())
             )
-    
+
     await cancel_in_progress_game(interaction, game_id)
-    
 
 
 @bot.command()
@@ -2498,6 +2494,7 @@ async def setgamecode(interaction: Interaction, code: str):
     )
     session.commit()
 
+    await interaction.response.defer(ephemeral=True)
     for ipg_player in ipg_players:
         embed = Embed(
             title=f"Lobby code for ({short_uuid(ipg.id)})",
@@ -2510,7 +2507,7 @@ async def setgamecode(interaction: Interaction, code: str):
                 interaction.guild, ipg_player.player_id, embed=embed
             )
     if ipg_players:
-        await interaction.response.send_message(
+        await interaction.followup.send(
             embed=Embed(
                 description="Lobby code sent to each player", colour=Colour.blue()
             ),
@@ -2518,7 +2515,7 @@ async def setgamecode(interaction: Interaction, code: str):
         )
     else:
         logging.warn("No in_progress_game_players to send a lobby code to")
-        await interaction.response.send_message(
+        await interaction.followup.send(
             embed=Embed(
                 description="There are no in-game players to send this lobby code to!",
                 colour=Colour.red(),
@@ -3456,7 +3453,7 @@ async def _rebalance_game(
                 embed_description=f"Players moved to new team voice channels for game {short_game_id}",
                 colour=Colour.green(),
             )
-    
+
     pass
 
 

--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from datetime import datetime, timezone
 
 import discord.utils
@@ -10,13 +11,12 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 import discord_bots.config as config
 from discord_bots.cogs.categories import CategoryCommands
+from discord_bots.cogs.economy import EconomyCommands
 from discord_bots.cogs.map import MapCommands
 from discord_bots.cogs.queue import QueueCommands
 from discord_bots.cogs.raffle import RaffleCommands
 from discord_bots.cogs.rotation import RotationCommands
 from discord_bots.cogs.vote import VoteCommands
-from discord_bots.cogs.economy import EconomyCommands
-from .views.in_progress_game import InProgressGameView
 
 from .bot import bot
 from .models import CustomCommand, Player, QueuePlayer, QueueWaitlistPlayer, Session
@@ -25,10 +25,11 @@ from .tasks import (
     afk_timer_task,
     leaderboard_task,
     map_rotation_task,
+    prediction_task,
     queue_waitlist_task,
     vote_passed_waitlist_task,
-    prediction_task,
 )
+from .views.in_progress_game import InProgressGameView
 
 
 async def create_seed_admins():
@@ -69,6 +70,13 @@ async def on_app_command_error(
 ) -> None:
     if isinstance(error, errors.CheckFailure):
         return
+    else:
+        if interaction.command:
+            logging.warning(
+                f"[on_app_command_error]: {error}, command: {interaction.command.name}"
+            )
+        else:
+            logging.warning(f"[on_app_command_error]: {error}")
 
 
 @bot.event
@@ -90,9 +98,9 @@ async def on_command_error(ctx: Context, error: CommandError):
             )
     else:
         if ctx.command:
-            print("[on_command_error]:", error, ", command:", ctx.command.name)
+            logging.warning(f"[on_command_error]: {error}, command: {ctx.command.name}")
         else:
-            print("[on_command_error]:", error)
+            logging.warning(f"[on_command_error]: {error}")
 
 
 @bot.event


### PR DESCRIPTION
In setgamecode, the interaction response was timing out because it wasn't being replied to in time. This was due to sending each player the game code taking too much time, so the solution was to `interaction.response.defer()` and then `interaction.followup.send(...)` later.