### PR TITLE
Fix: Create_Game crashing before call to _MoveGamePlayers

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -528,8 +528,8 @@ async def create_game(
         if (
             config.ENABLE_VOICE_MOVE
             and queue.move_enabled
-            and be_channel
-            and ds_channel
+            and be_voice_channel
+            and ds_voice_channel
         ):
             await _movegameplayers(short_game_id, None, guild)
             await send_message(


### PR DESCRIPTION
Bot currently crashes & hangs on game start due to a variable not found error.

Voice channel variable names were updated, but an instance where they were called was missed.
This has been tested in T3:OCE working in prod.