### PR TITLE
fix: incorrect var name, _movegameplayers finds correct voice channels instead of assuming based on row order

### DIFF
--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -715,7 +715,13 @@ async def print_leaderboard():
                         leaderboard_channel.last_message_id
                     )
                 if last_message:
-                    await last_message.edit(embed=Embed(description=output, colour=Colour.blue()))
+                    embed = Embed(
+                        description=output,
+                        colour=Colour.blue(),
+                        timestamp=discord.utils.utcnow(),
+                    )
+                    embed.set_footer(text="Last updated")
+                    await last_message.edit(embed=embed)
                     return
             except Exception as e:
                 _log.exception("[print_leaderboard] exception")


### PR DESCRIPTION
`_move_game_players` was assuming that the first row in the `in_progress_game_channel` table corresponded to the voice_channel1 and the second corresponded to voice_channel2. Instead, it now searches for the correct voice channels based on the team names, which is currently how they are created.