### PR TITLE
Add `bot.log` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__
 *.egg-info/
 build/
 tmp/
+bot.log


### PR DESCRIPTION
I noticed after running the server locally, that the `bot.log` file it produces is not excluded by Git.
This PR adds the affected file to the git ignore list.