### PR TITLE
Add vim to Dockerfile-base, Dockerhub image also updated

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ docker-compose.yml
 .dockerenv
 discord_bots/
 scripts/
+docker-compose-sqlite.yml

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -12,7 +12,7 @@
 FROM debian:stable-slim as debinstall
 SHELL [ "/bin/bash", "-c" ]
 RUN apt-get update
-RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install python3 python3-venv python3-pip python3-dev libpq-dev libjpeg-dev libffi-dev g++ make
+RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install python3 python3-venv python3-pip python3-dev libpq-dev libjpeg-dev libffi-dev g++ make vim
 
 FROM debinstall as usersetup
 RUN groupadd -g 999 tribesbot


### PR DESCRIPTION
It was requested that vim should be in the `technitaur/tribesbot:base` image for the Docker installation. I have updated the `Dockerfile-base` file to reflect this. My image on Dockerhub has also been updated: [link](https://hub.docker.com/layers/technitaur/tribesbot/base/images/sha256:5ff416655f23f04f3ee48b1443baa407ca5b8a9fd18389cf34473fb608c0d9f9?uuid=026B5842-0DAD-4FAB-9B06-C5085B9E68D1)

Those who have already been using the base image may need to delete it from their system in order to receive the updated version, but I don't know for sure. Try restarting your container and see if you can run vim in it. If that doesn't work, delete the container and the image (but not your volume!) and then `docker compose build && docker compose up` again.

This is a new process for me, so I apologize for any hiccups this may cause. Hopefully if it does cause issues, I can quickly figure out how to prevent that in future base image updates.