### PR TITLE
Bump pyyaml 6.0 -> 6.0.1 and Pillow 9.0.1 -> 10.3.0 to avoid local install issues

### DIFF
--- a/docs/running/RUNNING_DIRECTLY.md
+++ b/docs/running/RUNNING_DIRECTLY.md
@@ -13,28 +13,26 @@ simpler, you can run the bot on your server or local system.
 
 ### System dependencies
 
-You will need Postgres dev tools installed in order to be able to install the
-`psycopg2` Python dependency; these are also useful to be able to e.g. `psql` to
-your database.
+You will need a couple of specific system packages installed:
+* `libpq` as a dependency of the `psycopg2` pip package
+* `libjpeg-dev` as a dependency of the `Pillow` pip package
+  * (this is only here as a dependency of scipy, which is only used in the plotting script and not the running app)
 
-You can do this on various operating syste
+You can install these on various OSes as described below:
 
-Postgres is the new preferred way of doing development. To install `psycopg2`
-you'll need to install `libpq`.
-
-#### Ubuntu
+#### Ubuntu (or Ubuntu WSL)
 ```
-sudo apt-get install libpq-dev
+sudo apt-get install libpq-dev libjpeg-dev
 ```
 
 #### Arch linux
 ```
-pacman -S postgresql-libs
+pacman -S postgresql-libs libjpeg-turbo
 ```
 
 #### MacOS
 ```
-brew install postgresql
+brew install postgresql jpeg
 ```
 
 ### Python dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ outcome==1.1.0
 packaging==21.3
 pandas==2.2.0
 pathspec==0.9.0
-Pillow==9.0.1
+Pillow==10.3.0
 platformdirs==2.4.0
 pluggy==1.0.0
 pre-commit==2.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pytest-asyncio==0.16.0
 python-dateutil==2.8.2
 python-dotenv==0.19.2
 pytz==2021.3
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 scipy==1.12.0
 selenium==4.1.0


### PR DESCRIPTION
Tiny, tiny PR just because I couldn't get requirements installed on my machine due to:
* a [known issue with Pyyaml](https://github.com/yaml/pyyaml/issues/736) below 6.0.1
* the version of `Pillow` in the deps not being compatible with MacOS on ARM

For PyYaml it's a patch version bump so should be safe. And Pillow is only even here as a transitive dependency of scipy which is used in the script for plotting Trueskill, it shouldn't be actually required to run the app.