### PR TITLE
Prevent local .venv being copied into docker image and overwriting deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 build/
 discord_bots.egg-info/
 dist/
+.venv/
 .env.example
 .env
 .gitignore


### PR DESCRIPTION
Per discord we were seeing issues starting the bots in docker as a result of incompatible local virtualenvs being copied in during the main build.

This just excludes the local venv from being included in the docker copy.

Testing: before adding the line to the dockerignore, I got the error with `alembic` for `cannot execute` (caused by a shebang pointing at a path on my local system) and afterwards, it boots successfully.