### PR TITLE
Admin only autosub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ DATABASE_URI=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:5432/
 # into service.                                                      #
 ######################################################################
 
+# Makes the !autosub command only useable by admins
+# Defaults to False
+#ADMIN_AUTOSUB=
+
 # Idle timer for queues. Players are automatically removed from all
 # queues if no activity is registered for this amount of time. Defaults
 # to 45.

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1265,6 +1265,9 @@ async def autosub(ctx: Context, member: Member = None):
     assert message
     assert guild
 
+    if config.ADMIN_AUTOSUB and not await is_admin(ctx):
+            return
+
     player_in_game_id = member.id if member else message.author.id
     player_name = member.display_name if member else message.author.display_name
     ipg_player: InProgressGamePlayer | None = (

--- a/discord_bots/config.py
+++ b/discord_bots/config.py
@@ -169,4 +169,5 @@ STARTING_CURRENCY: int = _to_int(key="STARTING_CURRENCY", default=100)
 PREDICTION_TIMEOUT: int = _to_int(key="PREDICTION_TIMEOUT", default=300)
 CURRENCY_AWARD: int = _to_int(key="CURRENCY_AWARD", default=25)
 GAME_HISTORY_CHANNEL: int = _to_int(key="GAME_HISTORY_CHANNEL", required=True)
+ADMIN_AUTOSUB: bool = _to_bool(key="ADMIN_AUTOSUB", default=False)
 # TODO grouping here and in docs


### PR DESCRIPTION
- Adds a new `.env` variable: `ADMIN_AUTOSUB`.
- Default = Faluse
- When True, `!autosub` is only able to be used by admins, via the `.checks.is_admin()` check