### PR TITLE
feat: add mapstats and globalmapstats slash commands

### DIFF
--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -90,11 +90,11 @@ async def on_app_command_error(
         return
     else:
         if interaction.command:
-            _log.error(
+            _log.exception(
                 f"[on_app_command_error]: {error}, command: {interaction.command.name}"
             )
         else:
-            _log.error(f"[on_app_command_error]: {error}")
+            _log.exception(f"[on_app_command_error]: {error}")
 
 
 @bot.event


### PR DESCRIPTION
Adds two new slash commands:
1. `/mapstats category_name (optional)` [ephemeral]: shows your wins/losses/ties/total/WR per map in the specified category. If no category is specified, then your overall stats are displayed
2. `/globalmapstats` category_name (optional)` [not ephemeral]: shows the global team0_wins/team1_wins/ties/team0_win% per map for the specified category. If no category is specified, then your overall stats are displayed
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/691254e5-e9f9-4212-b815-172b4e568f82)
