### PR TITLE
Map configure

### DIFF
--- a/discord_bots/cogs/base.py
+++ b/discord_bots/cogs/base.py
@@ -3,17 +3,15 @@ from __future__ import annotations
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 from typing import TYPE_CHECKING
 
-import discord
 from discord import Colour, Embed, Interaction, TextChannel
 from discord.ext.commands import Cog, Context
-from discord.ui.item import Item
 
 from discord_bots.checks import HasName
 from discord_bots.models import Session
 from discord_bots.utils import send_message
 
 if TYPE_CHECKING:
-    from typing import Any, Type
+    from typing import Type
 
 
 class BaseCog(Cog):
@@ -78,38 +76,3 @@ class BaseCog(Cog):
                     colour=Colour.green(),
                 )
             )
-
-
-class BaseView(discord.ui.View):
-    async def on_error(
-        self,
-        interaction: discord.Interaction[discord.Client],
-        error: Exception,
-        item: Item[Any],
-    ) -> None:
-        if interaction.response.is_done():
-            await interaction.followup.send(
-                embed=discord.Embed(
-                    description="Oops! Something went wrong ☹️",
-                    color=discord.Color.red(),
-                ),
-                ephemeral=True,
-            )
-        else:
-            # fallback case that responds to the interaction, since there always needs to be a response
-            await interaction.response.send_message(
-                embed=discord.Embed(
-                    description="Oops! Something went wrong ☹️",
-                    color=discord.Color.red(),
-                ),
-                ephemeral=True,
-            )
-        await super().on_error(interaction, error, item)
-        return
-
-    async def disable_buttons(self, interaction: discord.Interaction):
-        for child in self.children:
-            if type(child) == discord.ui.Button and not child.disabled:
-                child.disabled = True
-        if interaction.message is not None:
-            await interaction.message.edit(view=self)

--- a/discord_bots/cogs/category.py
+++ b/discord_bots/cogs/category.py
@@ -9,6 +9,7 @@ from discord_bots.checks import is_admin_app_command, is_command_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Category, PlayerCategoryTrueskill, Queue, Session
 from discord_bots.utils import default_sigma_decay_amount, build_category_str
+from discord_bots.views.configure_category import CategoryConfigureView
 
 _log = logging.getLogger(__name__)
 

--- a/discord_bots/cogs/category.py
+++ b/discord_bots/cogs/category.py
@@ -19,22 +19,62 @@ class CategoryCommands(BaseCog):
 
     group = app_commands.Group(name="category", description="Category commands")
 
-    @group.command(name="create", description="Create a new category")
+    @group.command(name="configure", description="Create/Edit a category")
     @app_commands.check(is_admin_app_command)
     @app_commands.check(is_command_channel)
-    @app_commands.describe(name="Name of new category")
-    async def createcategory(self, interaction: Interaction, name: str):
+    @app_commands.describe(category_name="New or existing category")
+    async def configure(self, interaction: Interaction, category_name: str):
+        assert interaction.guild
+
+        new_category: bool = False
         session: SQLAlchemySession
         with Session() as session:
-            session.add(Category(name=name, is_rated=True, sigma_decay_amount=default_sigma_decay_amount()))
-            session.commit()
+            category: Category | None = (
+                session.query(Category)
+                .filter(Category.name.ilike(category_name))
+                .first()
+            )
+            if not category:
+                new_category = True
+                category = Category(
+                    name=category_name,
+                    is_rated=True,
+                    sigma_decay_amount=default_sigma_decay_amount(),
+                )
+
+            configure_view = CategoryConfigureView(interaction, category)
+            configure_view.embed = Embed(
+                description=f"**{category.name}** Category Configure\n-----",
+                colour=Colour.blue(),
+            )
             await interaction.response.send_message(
-                embed=Embed(
-                    description=f"Category **{name}** added",
-                    colour=Colour.green(),
-                ),
+                embed=configure_view.embed,
+                view=configure_view,
                 ephemeral=True,
             )
+
+            await configure_view.wait()
+            if configure_view.value:
+                if new_category:
+                    session.add(category)
+                session.commit()
+                await interaction.delete_original_response()
+                await interaction.followup.send(
+                    embed=Embed(
+                        description=f"**{configure_view.category.name}** has been configured!",
+                        colour=Colour.green(),
+                    ),
+                    ephemeral=True,
+                )
+            else:
+                await interaction.delete_original_response()
+                await interaction.followup.send(
+                    embed=Embed(
+                        description=f"**{category_name}** configuration cancelled",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
 
     @group.command(name="remove", description="Remove an existing category")
     @app_commands.check(is_admin_app_command)
@@ -69,184 +109,6 @@ class CategoryCommands(BaseCog):
                 )
             )
 
-    @group.command(name="setname", description="Set category name")
-    @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
-    @app_commands.describe(
-        old_category_name="Existing category", new_category_name="New category name"
-    )
-    @app_commands.rename(old_category_name="category")
-    async def setcategoryname(
-        self, interaction: Interaction, old_category_name: str, new_category_name: str
-    ):
-        """
-        Set category name
-        """
-        await self.setname(interaction, Category, old_category_name, new_category_name)
-
-    @group.command(name="setrated", description="Set category rated")
-    @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
-    @app_commands.describe(category_name="Existing category")
-    @app_commands.rename(category_name="category")
-    async def setcategoryrated(self, interaction: Interaction, category_name: str):
-        session: SQLAlchemySession
-        with Session() as session:
-            try:
-                category: Category = (
-                    session.query(Category)
-                    .filter(Category.name.ilike(category_name))
-                    .one()
-                )
-            except NoResultFound:
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Could not find category **{category_name}**",
-                        colour=Colour.red(),
-                    ),
-                    ephemeral=True,
-                )
-                return
-            else:
-                category.is_rated = True
-                session.commit()
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Category **{category.name}** changed to **rated**",
-                        colour=Colour.green(),
-                    )
-                )
-
-    @group.command(name="setsigmadecay", description="Set the amount of sigma decay per day for a given category")
-    @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
-    @app_commands.describe(category_name="Existing category")
-    @app_commands.rename(category_name="category")
-    async def setcategorysigmadecay(
-        self,
-        interaction: Interaction,
-        category_name: str,
-        sigma_decay_amount: float,
-        sigma_decay_grace_days: int,
-        sigma_decay_max_decay_proportion: float,
-    ) -> None:
-        """
-        Set the amount of sigma decay per day for a given category
-        """
-        session: SQLAlchemySession
-        with Session() as session:
-            try:
-                category: Category = (
-                    session.query(Category).filter(Category.name.ilike(category_name)).one()
-                )
-            except NoResultFound:
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Could not find category **{category_name}**",
-                        colour=Colour.red(),
-                    ),
-                    ephemeral=True
-                )
-                return
-            category.sigma_decay_amount = sigma_decay_amount
-            category.sigma_decay_grace_days = sigma_decay_grace_days
-            category.sigma_decay_max_decay_proportion = sigma_decay_max_decay_proportion
-            session.commit()
-
-        output = f"Sigma decay settings updated for **{category.name}**:\n"
-        output += f"- Decay amount: {sigma_decay_amount}\n"
-        output += f"- Grace days: {sigma_decay_grace_days}\n"
-        output += f"- Max decay proportion: {sigma_decay_max_decay_proportion}\n"
-        await interaction.response.send_message(
-            embed=Embed(
-                description=output,
-                colour=Colour.green(),
-            )
-        )
-
-    @group.command(name="setunrated", description="Set category unrated")
-    @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
-    @app_commands.describe(category_name="Existing category")
-    @app_commands.rename(category_name="category")
-    async def setcategoryunrated(self, interaction: Interaction, category_name: str):
-        session: SQLAlchemySession
-        with Session() as session:
-            try:
-                category: Category = (
-                    session.query(Category)
-                    .filter(Category.name.ilike(category_name))
-                    .one()
-                )
-            except NoResultFound:
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Could not find category **{category_name}**",
-                        colour=Colour.red(),
-                    ),
-                    ephemeral=True,
-                )
-                return
-            else:
-                category.is_rated = False
-                session.commit()
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Category **{category.name}** changed to **unrated**",
-                        colour=Colour.green(),
-                    )
-                )
-
-    @group.command(
-        name="setminleaderboardgames",
-        description="Set minimum number of games to be on the category leaderboard",
-    )
-    @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
-    @app_commands.describe(
-        category_name="Existing category",
-        min_num_games="Games required to show on the leaderboard",
-    )
-    @app_commands.rename(category_name="category")
-    async def setmingamesforleaderboard(
-        self,
-        interaction: Interaction,
-        category_name: str,
-        min_num_games: int,
-    ):
-        if min_num_games < 0:
-            await interaction.response.send_message(
-                embed=Embed(
-                    description=f"The minimum number of games must be non-negative",
-                    colour=Colour.red(),
-                ),
-                ephemeral=True,
-            )
-            return
-
-        session: SQLAlchemySession
-        with Session() as session:
-            category: Category | None = (
-                session.query(Category).filter(Category.name.ilike(category_name)).one()
-            )
-            if not category:
-                await interaction.response.send_message(
-                    embed=Embed(
-                        description=f"Could not find category **{category_name}**",
-                        colour=Colour.red(),
-                    ),
-                    ephemeral=True,
-                )
-                return
-            category.min_games_for_leaderboard = min_num_games
-            session.commit()
-        await interaction.response.send_message(
-            embed=Embed(
-                description=f"The minimum number of games required to appear on the leaderboard for category **{category.name}** is now **{min_num_games}**",
-                colour=Colour.green(),
-            )
-        )
-
     @group.command(name="show", description="Show category details")
     @app_commands.check(is_command_channel)
     @app_commands.describe(category_name="Existing category")
@@ -256,7 +118,9 @@ class CategoryCommands(BaseCog):
         with Session() as session:
             try:
                 category: Category = (
-                    session.query(Category).filter(Category.name.ilike(category_name)).one()
+                    session.query(Category)
+                    .filter(Category.name.ilike(category_name))
+                    .one()
                 )
             except NoResultFound:
                 await interaction.response.send_message(
@@ -264,7 +128,7 @@ class CategoryCommands(BaseCog):
                         description=f"Could not find category **{category_name}**",
                         colour=Colour.red(),
                     ),
-                    ephemeral=True
+                    ephemeral=True,
                 )
                 return
 
@@ -275,12 +139,8 @@ class CategoryCommands(BaseCog):
             )
         )
 
-    @createcategory.autocomplete("name")
+    @configure.autocomplete("category_name")
     @removecategory.autocomplete("name")
-    @setcategoryname.autocomplete("old_category_name")
-    @setcategoryrated.autocomplete("category_name")
-    @setcategoryunrated.autocomplete("category_name")
-    @setmingamesforleaderboard.autocomplete("category_name")
     @showcategory.autocomplete("category_name")
     async def category_autocomplete(self, interaction: Interaction, current: str):
         result = []

--- a/discord_bots/cogs/in_progress_game.py
+++ b/discord_bots/cogs/in_progress_game.py
@@ -1091,7 +1091,7 @@ class InProgressGameView(BaseView):
             interaction, "win", self.game_id
         )
         if self.is_game_finished:
-            await self.disable_buttons(interaction)
+            await self.disable_children(interaction)
             self.stop()
 
     @button(
@@ -1105,7 +1105,7 @@ class InProgressGameView(BaseView):
             interaction, "loss", self.game_id
         )
         if self.is_game_finished:
-            await self.disable_buttons(interaction)
+            await self.disable_children(interaction)
             self.stop()
 
     @button(
@@ -1119,7 +1119,7 @@ class InProgressGameView(BaseView):
             interaction, "tie", self.game_id
         )
         if self.is_game_finished:
-            await self.disable_buttons(interaction)
+            await self.disable_children(interaction)
             self.stop()
 
     @button(

--- a/discord_bots/cogs/in_progress_game.py
+++ b/discord_bots/cogs/in_progress_game.py
@@ -26,8 +26,6 @@ from trueskill import Rating, rate
 
 from discord_bots import config
 from discord_bots.checks import is_admin_app_command, is_command_channel
-from discord_bots.cogs.base import BaseView
-from discord_bots.cogs.confirmation import ConfirmationView
 from discord_bots.cogs.economy import EconomyCommands
 from discord_bots.models import (
     Category,
@@ -64,6 +62,8 @@ from discord_bots.utils import (
     get_n_worst_teams,
     mock_teams_str,
 )
+from discord_bots.views.base import BaseView
+from discord_bots.views.confirmation import ConfirmationView
 
 if TYPE_CHECKING:
     from discord.ext.commands import Bot

--- a/discord_bots/views/base.py
+++ b/discord_bots/views/base.py
@@ -1,13 +1,8 @@
 import logging
 from typing import Any
 
-from discord import (
-    Client,
-    Colour, 
-    Embed,
-    Interaction
-)
-from discord.ui import Button, View
+from discord import Client, Colour, Embed, Interaction
+from discord.ui import View
 from discord.ui.item import Item
 
 _log = logging.getLogger(__name__)
@@ -40,9 +35,30 @@ class BaseView(View):
         await super().on_error(interaction, error, item)
         return
 
-    async def disable_buttons(self, interaction: Interaction):
+    async def disable_children(self, interaction: Interaction):
         for child in self.children:
-            if type(child) == Button and not child.disabled:
-                child.disabled = True
-        if interaction.message is not None:
-            await interaction.message.edit(view=self)
+            if not child.disabled:  # type: ignore
+                try:
+                    child.disabled = True  # type: ignore
+                except Exception:
+                    pass
+
+        if interaction.response.is_done():
+            await interaction.edit_original_response(view=self)
+        else:
+            if interaction.message is not None:
+                await interaction.message.edit(view=self)
+
+    async def enable_children(self, interaction: Interaction):
+        for child in self.children:
+            if child.disabled:  # type: ignore
+                try:
+                    child.disabled = False  # type: ignore
+                except Exception:
+                    pass
+
+        if interaction.response.is_done():
+            await interaction.edit_original_response(view=self)
+        else:
+            if interaction.message is not None:
+                await interaction.message.edit(view=self)

--- a/discord_bots/views/base.py
+++ b/discord_bots/views/base.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Any
+
+from discord import (
+    Client,
+    Colour, 
+    Embed,
+    Interaction
+)
+from discord.ui import Button, View
+from discord.ui.item import Item
+
+_log = logging.getLogger(__name__)
+
+
+class BaseView(View):
+    async def on_error(
+        self,
+        interaction: Interaction[Client],
+        error: Exception,
+        item: Item[Any],
+    ) -> None:
+        if interaction.response.is_done():
+            await interaction.followup.send(
+                embed=Embed(
+                    description="Oops! Something went wrong ☹️",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+        else:
+            # fallback case that responds to the interaction, since there always needs to be a response
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Oops! Something went wrong ☹️",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+        await super().on_error(interaction, error, item)
+        return
+
+    async def disable_buttons(self, interaction: Interaction):
+        for child in self.children:
+            if type(child) == Button and not child.disabled:
+                child.disabled = True
+        if interaction.message is not None:
+            await interaction.message.edit(view=self)

--- a/discord_bots/views/configure_category.py
+++ b/discord_bots/views/configure_category.py
@@ -1,0 +1,317 @@
+import logging
+from typing import List
+
+from discord import (
+    ButtonStyle,
+    Client,
+    Colour,
+    Embed,
+    Interaction,
+    SelectOption,
+    TextStyle,
+)
+from discord.ui import button, Button, Modal, Select, TextInput
+
+from discord_bots.models import Category
+from discord_bots.views.base import BaseView
+from discord_bots.views.confirmation import ConfirmationView
+
+_log = logging.getLogger(__name__)
+
+
+class CategoryConfigureView(BaseView):
+    def __init__(self, interaction: Interaction, category: Category):
+        super().__init__(timeout=300)
+        self.value: bool = False
+        self.category: Category = category
+        self.interaction: Interaction = interaction
+        self.embed: Embed
+        self.add_item(CategoryRatedSelect(self))
+
+    @button(label="Set Name", style=ButtonStyle.primary, row=0)
+    async def setname(self, interaction: Interaction, button: Button):
+        modal = CategoryNameModal(self)
+        await interaction.response.send_modal(modal)
+        return True
+
+    @button(label="Leaderboard Settings", style=ButtonStyle.primary, row=0)
+    async def leaderboard(self, interaction: Interaction, button: Button):
+        modal = CategoryLeaderboardModal(self)
+        await interaction.response.send_modal(modal)
+        return True
+
+    @button(label="Decay Settings", style=ButtonStyle.primary, row=0)
+    async def decay(self, interaction: Interaction, button: Button):
+        modal = CategoryDecayModal(self)
+        await interaction.response.send_modal(modal)
+        return True
+
+    @button(label="Save", style=ButtonStyle.success, row=4)
+    async def save(self, interaction: Interaction, button: Button):
+        await interaction.response.defer()
+        confirmation_buttons = ConfirmationView(interaction.user.id)
+        confirmation_buttons.message = await interaction.followup.send(
+            embed=Embed(
+                description=f"⚠️ Are you sure you want to save configurations for category **{self.category.name}**?⚠️",
+                colour=Colour.yellow(),
+            ),
+            view=confirmation_buttons,
+            ephemeral=True,
+        )
+        await confirmation_buttons.wait()
+        if not confirmation_buttons.value:
+            return False
+        else:
+            self.value = True
+            self.stop()
+            return True
+
+    @button(label="Cancel", style=ButtonStyle.danger, row=4)
+    async def cancel(self, interaction: Interaction, button: Button):
+        self.stop()
+        return False
+
+
+class CategoryDecayModal(Modal):
+    def __init__(
+        self,
+        view: CategoryConfigureView,
+    ):
+        super().__init__(title="Decay Settings", timeout=30)
+        self.view: CategoryConfigureView = view
+        self.sigma_decay_amount: TextInput = TextInput(
+            label="Sigma decay amount",
+            style=TextStyle.short,
+            required=False,
+            placeholder=str(self.view.category.sigma_decay_amount),
+        )
+        self.sigma_decay_grace_days: TextInput = TextInput(
+            label="Sigma decay grace days",
+            style=TextStyle.short,
+            required=False,
+            placeholder=str(self.view.category.sigma_decay_grace_days),
+        )
+        self.sigma_decay_max_decay_proportion: TextInput = TextInput(
+            label="Sigma decay max decay proportion",
+            style=TextStyle.short,
+            required=False,
+            placeholder=str(self.view.category.sigma_decay_max_decay_proportion),
+        )
+        self.add_item(self.sigma_decay_amount)
+        self.add_item(self.sigma_decay_grace_days)
+        self.add_item(self.sigma_decay_max_decay_proportion)
+
+    async def on_submit(self, interaction: Interaction[Client]) -> None:
+        self.decay_amount: float | None = None
+        self.decay_grace_days: int | None = None
+        self.decay_max_decay_proportion: float | None = None
+
+        try:
+            if not str(self.sigma_decay_amount) == "":
+                self.decay_amount = float(str(self.sigma_decay_amount))
+            if not str(self.sigma_decay_max_decay_proportion) == "":
+                self.decay_max_decay_proportion = float(
+                    str(self.sigma_decay_max_decay_proportion)
+                )
+        except Exception:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Decay amount & proportion must be a decimal number",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        try:
+            if not str(self.sigma_decay_grace_days) == "":
+                self.decay_grace_days = int(str(self.sigma_decay_grace_days))
+        except Exception:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Decay grace days must be an integer",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        # Check for zero's
+        if (
+            (self.decay_amount and self.decay_amount < 0)
+            or (self.decay_grace_days and self.decay_grace_days < 0)
+            or (self.decay_max_decay_proportion and self.decay_max_decay_proportion < 0)
+        ):
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Value must be greater than or equal to 0",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if self.decay_amount:
+            self.view.category.sigma_decay_amount = self.decay_amount
+            if self.view.embed.description:
+                self.view.embed.description = (
+                    self.view.embed.description
+                    + f"\nSigma decay amount: **{self.view.category.sigma_decay_amount}**"
+                )
+
+        if self.decay_grace_days:
+            self.view.category.sigma_decay_grace_days = self.decay_grace_days
+            if self.view.embed.description:
+                self.view.embed.description = (
+                    self.view.embed.description
+                    + f"\nSigma decay grace days: **{self.view.category.sigma_decay_grace_days}**"
+                )
+
+        if self.decay_max_decay_proportion:
+            self.view.category.sigma_decay_max_decay_proportion = (
+                self.decay_max_decay_proportion
+            )
+            if self.view.embed.description:
+                self.view.embed.description = (
+                    self.view.embed.description
+                    + f"\nSigma max decay proportion: **{self.view.category.sigma_decay_max_decay_proportion}**"
+                )
+
+        await self.view.interaction.edit_original_response(embed=self.view.embed)
+
+        # Interaction must be responded to, but is then deleted
+        await interaction.response.send_message(
+            embed=Embed(
+                description=f"Set decay settings successful",
+                colour=Colour.blue(),
+            ),
+            ephemeral=True,
+        )
+        await interaction.delete_original_response()
+        return
+
+
+class CategoryLeaderboardModal(Modal):
+    def __init__(
+        self,
+        view: CategoryConfigureView,
+    ):
+        super().__init__(title="Leaderboard Settings", timeout=30)
+        self.view: CategoryConfigureView = view
+        self.input: TextInput = TextInput(
+            label="Min games for leaderboard",
+            style=TextStyle.short,
+            required=True,
+            placeholder=str(self.view.category.min_games_for_leaderboard),
+        )
+        self.add_item(self.input)
+
+    async def on_submit(self, interaction: Interaction[Client]) -> None:
+        try:
+            self.value = int(str(self.input))
+        except Exception as e:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Value must be an integer",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        if self.value < 0:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Value must be greater than or equal to 0",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        self.view.category.min_games_for_leaderboard = self.value
+        if self.view.embed.description:
+            self.view.embed.description = (
+                self.view.embed.description
+                + f"\nMin games for leaderboard: **{self.view.category.min_games_for_leaderboard}**"
+            )
+        await self.view.interaction.edit_original_response(embed=self.view.embed)
+
+        # Interaction must be responded to, but is then deleted
+        await interaction.response.send_message(
+            embed=Embed(
+                description=f"Set min games for leaderboard **{self.view.category.min_games_for_leaderboard}** successful",
+                colour=Colour.blue(),
+            ),
+            ephemeral=True,
+        )
+        await interaction.delete_original_response()
+        return
+
+
+class CategoryNameModal(Modal):
+    def __init__(
+        self,
+        view: CategoryConfigureView,
+    ):
+        super().__init__(title="Set Name", timeout=30)
+        self.view: CategoryConfigureView = view
+        self.input: TextInput = TextInput(
+            label="Category Name",
+            style=TextStyle.short,
+            required=True,
+            placeholder=self.view.category.name,
+        )
+        self.add_item(self.input)
+
+    async def on_submit(self, interaction: Interaction[Client]) -> None:
+        self.view.category.name = self.input.value
+        if self.view.embed.description:
+            self.view.embed.description = (
+                self.view.embed.description
+                + f"\nCategory name: **{self.view.category.name}**"
+            )
+        await self.view.interaction.edit_original_response(embed=self.view.embed)
+
+        # Interaction must be responded to, but is then deleted
+        await interaction.response.send_message(
+            embed=Embed(
+                description=f"Set name **{self.view.category.name}** successful",
+                colour=Colour.blue(),
+            ),
+            ephemeral=True,
+        )
+        await interaction.delete_original_response()
+        return
+
+
+class CategoryRatedSelect(Select):
+    def __init__(self, view: CategoryConfigureView):
+        super().__init__(
+            placeholder=f"Is_Rated: {str(view.category.is_rated)}",
+            row=1,
+            options=[
+                SelectOption(label="Is_Rated: True", value="True"),
+                SelectOption(label="Is_Rated: False", value="False"),
+            ],
+        )
+        self.view: CategoryConfigureView
+
+    async def callback(self, interaction: Interaction[Client]):
+        self.view.category.is_rated = self.values[0] == "True"
+        if self.view.embed.description:
+            self.view.embed.description = (
+                self.view.embed.description
+                + f"\nIs_Rated set: **{self.view.category.is_rated}**"
+            )
+        await self.view.interaction.edit_original_response(embed=self.view.embed)
+
+        await interaction.response.send_message(
+            embed=Embed(
+                description=f"Set is_rated **{self.view.category.is_rated}** successful",
+                colour=Colour.blue(),
+            ),
+            ephemeral=True,
+        )
+        await interaction.delete_original_response()
+        return

--- a/discord_bots/views/configure_category.py
+++ b/discord_bots/views/configure_category.py
@@ -290,8 +290,8 @@ class CategoryRatedSelect(Select):
             placeholder=f"Is_Rated: {str(view.category.is_rated)}",
             row=1,
             options=[
-                SelectOption(label="Is_Rated: True", value="True"),
-                SelectOption(label="Is_Rated: False", value="False"),
+                SelectOption(label="True", value="True"),
+                SelectOption(label="False", value="False"),
             ],
         )
         self.view: CategoryConfigureView

--- a/discord_bots/views/configure_category.py
+++ b/discord_bots/views/configure_category.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from discord import (
     ButtonStyle,

--- a/discord_bots/views/configure_category.py
+++ b/discord_bots/views/configure_category.py
@@ -48,6 +48,8 @@ class CategoryConfigureView(BaseView):
     @button(label="Save", style=ButtonStyle.success, row=4)
     async def save(self, interaction: Interaction, button: Button):
         await interaction.response.defer()
+        await self.disable_children(interaction)
+
         confirmation_buttons = ConfirmationView(interaction.user.id)
         confirmation_buttons.message = await interaction.followup.send(
             embed=Embed(
@@ -59,6 +61,7 @@ class CategoryConfigureView(BaseView):
         )
         await confirmation_buttons.wait()
         if not confirmation_buttons.value:
+            await self.enable_children(interaction)
             return False
         else:
             self.value = True

--- a/discord_bots/views/configure_category.py
+++ b/discord_bots/views/configure_category.py
@@ -301,7 +301,7 @@ class CategoryRatedSelect(Select):
         if self.view.embed.description:
             self.view.embed.description = (
                 self.view.embed.description
-                + f"\nIs_Rated set: **{self.view.category.is_rated}**"
+                + f"\nIs_Rated: **{self.view.category.is_rated}**"
             )
         await self.view.interaction.edit_original_response(embed=self.view.embed)
 

--- a/discord_bots/views/configure_map.py
+++ b/discord_bots/views/configure_map.py
@@ -1,0 +1,115 @@
+import logging
+
+from discord import (
+    ButtonStyle,
+    Client,
+    Colour,
+    Embed,
+    Interaction,
+    SelectOption,
+    TextStyle,
+)
+from discord.ui import button, Button, Modal, Select, TextInput
+
+from discord_bots.models import Map
+from discord_bots.views.base import BaseView
+from discord_bots.views.confirmation import ConfirmationView
+
+_log = logging.getLogger(__name__)
+
+
+class MapConfigureView(BaseView):
+    def __init__(self, interaction: Interaction, map: Map):
+        super().__init__(timeout=300)
+        self.value: bool = False
+        self.map: Map = map
+        self.interaction: Interaction = interaction
+        self.embed: Embed
+    
+    @button(label="Set Name", style=ButtonStyle.primary, row=0)
+    async def setname(self, interaction: Interaction, button: Button):
+        modal = MapNameModal(self)
+        await interaction.response.send_modal(modal)
+        return True
+    
+    @button(label="Save", style=ButtonStyle.success, row=4)
+    async def save(self, interaction: Interaction, button: Button):
+        if self.map.short_name == "" or self.map.full_name == "":
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Map full name & short name must not be empty",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True
+            )
+            return
+        
+        await interaction.response.defer()
+        confirmation_buttons = ConfirmationView(interaction.user.id)
+        confirmation_buttons.message = await interaction.followup.send(
+            embed=Embed(
+                description=f"⚠️ Are you sure you want to save configurations for category **{self.map.full_name}**?⚠️",
+                colour=Colour.yellow(),
+            ),
+            view=confirmation_buttons,
+            ephemeral=True,
+        )
+        await confirmation_buttons.wait()
+        if not confirmation_buttons.value:
+            return False
+        else:
+            self.value = True
+            self.stop()
+            return True
+
+    @button(label="Cancel", style=ButtonStyle.danger, row=4)
+    async def cancel(self, interaction: Interaction, button: Button):
+        self.stop()
+        return False
+    
+
+class MapNameModal(Modal):
+    def __init__(
+        self,
+        view: MapConfigureView,
+    ):
+        super().__init__(title="Set Name", timeout=30)
+        self.view: MapConfigureView = view
+        self.short_name: TextInput = TextInput(
+            label="Short Name",
+            style=TextStyle.short,
+            required=False,
+            placeholder=self.view.map.short_name,
+        )
+        self.full_name: TextInput = TextInput(
+            label="Full Name",
+            style=TextStyle.short,
+            required=False,
+            placeholder=self.view.map.full_name,
+        )
+        self.add_item(self.short_name)
+        self.add_item(self.full_name)
+
+    async def on_submit(self, interaction: Interaction[Client]) -> None:
+        if not self.short_name.value == "":
+            self.view.map.short_name = self.short_name.value
+        if not self.full_name.value == "":
+            self.view.map.full_name = self.full_name.value
+
+        if self.view.embed.description:
+            self.view.embed.description = (
+                self.view.embed.description
+                + f"\nMap name: **{self.view.map.full_name} ({self.view.map.short_name})**"
+            )
+        await self.view.interaction.edit_original_response(embed=self.view.embed)
+
+        # Interaction must be responded to, but is then deleted
+        await interaction.response.send_message(
+            embed=Embed(
+                description=f"Set name **{self.view.map.full_name}** (**{self.view.map.short_name}**) successful",
+                colour=Colour.blue(),
+            ),
+            ephemeral=True,
+        )
+        await interaction.delete_original_response()
+        return

--- a/discord_bots/views/configure_map.py
+++ b/discord_bots/views/configure_map.py
@@ -25,13 +25,13 @@ class MapConfigureView(BaseView):
         self.map: Map = map
         self.interaction: Interaction = interaction
         self.embed: Embed
-    
+
     @button(label="Set Name", style=ButtonStyle.primary, row=0)
     async def setname(self, interaction: Interaction, button: Button):
         modal = MapNameModal(self)
         await interaction.response.send_modal(modal)
         return True
-    
+
     @button(label="Save", style=ButtonStyle.success, row=4)
     async def save(self, interaction: Interaction, button: Button):
         if self.map.short_name == "" or self.map.full_name == "":
@@ -40,11 +40,13 @@ class MapConfigureView(BaseView):
                     description="Map full name & short name must not be empty",
                     colour=Colour.red(),
                 ),
-                ephemeral=True
+                ephemeral=True,
             )
             return
-        
+
         await interaction.response.defer()
+        await self.disable_children(interaction)
+
         confirmation_buttons = ConfirmationView(interaction.user.id)
         confirmation_buttons.message = await interaction.followup.send(
             embed=Embed(
@@ -56,6 +58,7 @@ class MapConfigureView(BaseView):
         )
         await confirmation_buttons.wait()
         if not confirmation_buttons.value:
+            await self.enable_children(interaction)
             return False
         else:
             self.value = True
@@ -66,7 +69,7 @@ class MapConfigureView(BaseView):
     async def cancel(self, interaction: Interaction, button: Button):
         self.stop()
         return False
-    
+
 
 class MapNameModal(Modal):
     def __init__(

--- a/discord_bots/views/confirmation.py
+++ b/discord_bots/views/confirmation.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 import discord
 
-from discord_bots.cogs.base import BaseView
+from discord_bots.views.base import BaseView
 
 
 class ConfirmationView(BaseView):


### PR DESCRIPTION
**Dependant on PR #98**

In a similar fashion to PR #98, this PR includes the `/map configure <map_name>` command.

Maps being a very simple entity type, the configuration setup is much simpler, and the only configurable variables are `map.short_name` & `map.full_name`.
Configuration ensures that both are filled.

Creating map names through interaction / modal allows for whitespace in names, where the previous context commands did not.

All basic configuration functionality (save / cancel / timeout etc) are duplicated from category, to maintain a standard functionality across entities.

![image](https://github.com/tribesonecommunity/discord-bots/assets/53620706/0eb9d5ca-a200-44eb-afea-c3eb5ddfd207)

`/map add` has been removed

**DO NOT MERGE UNTIL AFTER PR #98**
