### PR TITLE
Make PCT last_game_finished_at non-null and defaulting to current timestamp

### DIFF
--- a/alembic/versions/20240504092141_eac69ad70805_make_last_game_finished_at_non_nullable.py
+++ b/alembic/versions/20240504092141_eac69ad70805_make_last_game_finished_at_non_nullable.py
@@ -1,0 +1,35 @@
+"""make last game finished at non-nullable
+
+Revision ID: eac69ad70805
+Revises: ef83c87be4de
+Create Date: 2024-05-04 09:21:41.394787
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql.expression import text
+from sqlalchemy.sql.functions import now
+
+# revision identifiers, used by Alembic.
+revision = "eac69ad70805"
+down_revision = "ef83c87be4de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Note, this is non-reversible  
+    # If you downgrade, the rows that were previously null will not lose their value
+    op.execute("UPDATE player_category_trueskill SET last_game_finished_at = NOW() WHERE last_game_finished_at IS NULL")
+    with op.batch_alter_table("player_category_trueskill", schema=None) as batch_op:
+        batch_op.alter_column("last_game_finished_at", 
+                              existing_type=sa.DateTime(), 
+                              nullable=False, 
+                              server_default=now())
+
+
+def downgrade():
+    with op.batch_alter_table("player_category_trueskill", schema=None) as batch_op:
+        batch_op.alter_column("last_game_finished_at", 
+                              existing_type=sa.DateTime(), 
+                              nullable=True)

--- a/discord_bots/models.py
+++ b/discord_bots/models.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship  # type: ignore
 from sqlalchemy.orm import registry, scoped_session, sessionmaker
 from sqlalchemy.sql import expression, func
+from sqlalchemy.sql.functions import now as sql_now
 from sqlalchemy.sql.schema import ForeignKey, MetaData
 
 import discord_bots.config as config
@@ -898,7 +899,14 @@ class PlayerCategoryTrueskill:
     sigma: float = field(metadata={"sa": Column(Float, nullable=False)})
     rank: float = field(metadata={"sa": Column(Float, nullable=False)})
     last_game_finished_at: datetime = field(
-        metadata={"sa": Column(DateTime, nullable=True, index=True)}
+        metadata={
+                "sa": Column(
+                    DateTime, 
+                    nullable=False, 
+                    server_default=sql_now(), 
+                    index=True
+                )
+            }
     )
     created_at: datetime = field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -635,10 +635,7 @@ async def sigma_decay_task():
             session
             .query(PlayerCategoryTrueskill)
             .filter(
-                sqlalchemy.and_(
-                    PlayerCategoryTrueskill.last_game_finished_at.is_not(None),
-                    PlayerCategoryTrueskill.category_id.in_(category_details.keys())
-                )
+                PlayerCategoryTrueskill.category_id.in_(category_details.keys())
             )
             .all()
         )


### PR DESCRIPTION
In order to address the issue that a player who has not played since decay was introduced will never decay, this PR makes the column non-nullable. To facilitate this it sets the server default to the current timestamp on creation, and updates all existing null rows to the current timestamp (i.e. we do not try to retroactively decay players who are not active, but we can start decaying them from the time of upgrade).

One downside to this is that the alembic migration is not strictly reversible – it updates existing rows and therefore a downgrade will not magically make those rows have a null timestamp again.