### PR TITLE
fix: afk timeout to normal message for mobile notifications

### DIFF
--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -228,10 +228,8 @@ async def afk_timer_task():
                     if member:
                         await send_message(
                             channel,
-                            content=member.mention,
+                            content=f"{member.mention} was removed from all queues for being inactive for {config.AFK_TIME_MINUTES} minutes",
                             embed_content=False,
-                            embed_description=f"{escape_markdown(player.name)} was removed from all queues for being inactive for {config.AFK_TIME_MINUTES} minutes",
-                            colour=Colour.red(),
                         )
                 session.query(QueuePlayer).filter(
                     QueuePlayer.player_id == player.id


### PR DESCRIPTION
The current AFK timeout message, which posts a `discord.Embed` doesn't render properly for mobile hence the push notification will look like this:
![old](https://github.com/tribesonecommunity/discord-bots/assets/27743409/7bcd5115-ac60-4d38-9135-893451e64e7a)

This PR switches it to a regular message to fix that.
Note: desktop doesn't have this issue, but I felt like the AFK timer message would be more applicable to someone checking their phone. 
Leaving this PR up if anyone has any comments