### PR TITLE
style: make list commands ephemeral. fix: queue status player sorting, sigma decay not updating rank

### DIFF
--- a/discord_bots/cogs/list.py
+++ b/discord_bots/cogs/list.py
@@ -44,7 +44,8 @@ class ListCommands(BaseCog):
                 output += f"\n- {escape_markdown(player.name)}"
 
         await interaction.response.send_message(
-            embed=Embed(description=output, colour=Colour.blue())
+            embed=Embed(description=output, colour=Colour.blue()),
+            ephemeral=True,
         )
 
     @group.command(name="adminrole", description="List admin roles")
@@ -71,7 +72,8 @@ class ListCommands(BaseCog):
         output += f"\n{', '.join(admin_role_names)}"
 
         await interaction.response.send_message(
-            embed=Embed(description=output, colour=Colour.blue())
+            embed=Embed(description=output, colour=Colour.blue()),
+            ephemeral=True,
         )
 
     @group.command(name="ban", description="List banned players")
@@ -86,7 +88,8 @@ class ListCommands(BaseCog):
             embed=Embed(
                 description=output,
                 colour=Colour.blue(),
-            )
+            ),
+            ephemeral=True,
         )
 
     @group.command(name="category", description="List categories")
@@ -107,14 +110,11 @@ class ListCommands(BaseCog):
                 )
                 return
 
-            output = "\n".join(
-                build_category_str(category) 
-                for category 
-                in categories
-            )
+            output = "\n".join(build_category_str(category) for category in categories)
 
             await interaction.response.send_message(
-                embed=Embed(description=output, colour=Colour.blue())
+                embed=Embed(description=output, colour=Colour.blue()),
+                ephemeral=True,
             )
 
     @group.command(name="channel", description="List bot channels")
@@ -169,7 +169,8 @@ class ListCommands(BaseCog):
                 embed=Embed(
                     description=output,
                     colour=Colour.blue(),
-                )
+                ),
+                ephemeral=True,
             )
 
     @group.command(name="notification", description="List your notifications")
@@ -255,7 +256,8 @@ class ListCommands(BaseCog):
                 embed=Embed(
                     description=output,
                     colour=Colour.blue(),
-                )
+                ),
+                ephemeral=True,
             )
 
     @group.command(
@@ -289,7 +291,8 @@ class ListCommands(BaseCog):
                         queue_role_names.append(str(queue_role.role_id))
                 output += f"**{queue.name}**: {', '.join(queue_role_names)}\n"
             await interaction.response.send_message(
-                embed=Embed(description=output, colour=Colour.blue())
+                embed=Embed(description=output, colour=Colour.blue()),
+                ephemeral=True,
             )
 
     @group.command(
@@ -309,7 +312,8 @@ class ListCommands(BaseCog):
                 await interaction.response.send_message(
                     embed=Embed(
                         description="_-- No Rotations-- _", colour=Colour.blue()
-                    )
+                    ),
+                    ephemeral=True,
                 )
                 return
 
@@ -348,5 +352,6 @@ class ListCommands(BaseCog):
                     output += f" - Queues:  {', '.join(queue_names)}\n"
 
             await interaction.response.send_message(
-                embed=Embed(description=output, colour=Colour.blue())
+                embed=Embed(description=output, colour=Colour.blue()),
+                ephemeral=True,
             )

--- a/discord_bots/cogs/map.py
+++ b/discord_bots/cogs/map.py
@@ -609,8 +609,9 @@ class MapCommands(BaseCog):
             content = "Global Map Stats"
         content += f"\n{code_block(table)}"
         await interaction.response.send_message(
-            content=content
-        )  # TODO: consider making this ephemeral, or giving the option to choose
+            content=content,
+            ephemeral=True,
+        )
 
     @mapstats.autocomplete("category_name")
     async def category_autocomplete_with_user_id(

--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -646,4 +646,5 @@ async def sigma_decay_task():
                     pct.sigma + category.sigma_decay_amount,
                     config.DEFAULT_TRUESKILL_SIGMA * category.sigma_decay_max_decay_proportion,
                 )
+                pct.rank = pct.mu - (3 * pct.sigma)
         session.commit()

--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -102,13 +102,14 @@ async def add_players(session: sqlalchemy.orm.Session):
         for queue in queues_added_to_by_id.values():
             if queue.is_locked:
                 continue
+            # select from the QueuePlayer table to preserve the order in which players were added
             result = (
-                session.query(Player.name)
-                .join(QueuePlayer)
+                session.query(QueuePlayer, Player.name)
+                .join(Player, QueuePlayer.player_id == Player.id)
                 .filter(QueuePlayer.queue_id == queue.id)
                 .all()
             )
-            player_names: list[str] = [name[0] for name in result] if result else []
+            player_names: list[str] = [name[1] for name in result] if result else []
             queue_title_str = (
                 f"(**{queue.ordinal}**) {queue.name} [{len(player_names)}/{queue.size}]"
             )


### PR DESCRIPTION
1. Changed all `/list...` commands (as well as `/map globalstats`) to reply ephemerally.
2. Fixed an issue with the player names in the queue status not displaying based on insertion order. The issue was that it was selecting from the `Player` table and joining with the `QueuePlayer` table, so it was displaying based on the insertion order of the `Player` table.
3. Sigma decay not updating rank