### PR TITLE
Condense stats format, bold winning player names, increase win pct rounding to 1 digit from 0

### DIFF
--- a/discord_bots/cogs/common.py
+++ b/discord_bots/cogs/common.py
@@ -414,12 +414,7 @@ class CommonCommands(BaseCog):
                 return cols
 
             embeds: list[Embed] = []
-            trueskill_url = "https://www.microsoft.com/en-us/research/project/trueskill-ranking-system/"
-            footer_text = "{}\n{}\n{}".format(
-                f"Rating = {MU_LOWER_UNICODE} - 3*{SIGMA_LOWER_UNICODE}",
-                f"{MU_LOWER_UNICODE} (mu) = your average Rating",
-                f"{SIGMA_LOWER_UNICODE} (sigma) = the uncertainity of your Rating",
-            )
+            footer_text = f"Rating = {MU_LOWER_UNICODE} - 3*{SIGMA_LOWER_UNICODE}"
             cols = []
             conditions = []
             conditions.append(PlayerCategoryTrueskill.player_id == player.id)
@@ -450,12 +445,13 @@ class CommonCommands(BaseCog):
                             embed=Embed(description="Could not find your stats")
                         )
                         return
-                    title = f"Stats for {category.name}"
-                    description = ""
+                    title = f"{category.name} TrueSkill Stats"
                     if category.is_rated and SHOW_TRUESKILL:
-                        description = f"Rating: {round(pct.rank, 1)}"
-                        description += f"\n{MU_LOWER_UNICODE}: {round(pct.mu, 1)}"
-                        description += f"\n{SIGMA_LOWER_UNICODE}: {round(pct.sigma, 1)}"
+                        description = (
+                            f"Rating: **{round(pct.rank, 1)}**"
+                            f" (`{MU_LOWER_UNICODE}: {round(pct.mu, 1)}`, "
+                            f"`{SIGMA_LOWER_UNICODE}: {round(pct.sigma, 1)}`)"
+                        )
                     else:
                         description = f"Rating: {trueskill_pct}"
 
@@ -471,7 +467,7 @@ class CommonCommands(BaseCog):
                         first_col_heading=True,
                         style=PresetStyle.plain,
                         alignments=[
-                            Alignment.LEFT,
+                            Alignment.RIGHT,
                             Alignment.DECIMAL,
                             Alignment.DECIMAL,
                             Alignment.DECIMAL,
@@ -482,18 +478,19 @@ class CommonCommands(BaseCog):
                     description += code_block(table)
                     embed = Embed(title=title, description=description)
                     if i == (num_pct - 1):
-                        description += f"\n{trueskill_url}"
+                        # only add the footer to the last embed so we don't duplicate the information
                         embed.set_footer(text=footer_text)
                     embeds.append(embed)
-            if not player_category_trueskills:
+            else:
                 # no categories defined, display their global trueskill stats
                 description = ""
                 if SHOW_TRUESKILL:
-                    description = f"Rating: {round(player.rated_trueskill_mu - 3 * player.rated_trueskill_sigma, 2)}"
-                    description += (
-                        f"\n{MU_LOWER_UNICODE}: {round(player.rated_trueskill_mu, 1)}"
+                    rank = player.rated_trueskill_mu - 3 * player.rated_trueskill_sigma
+                    description = (
+                        f"Rating: **{round(rank, 1)}**"
+                        f" (`{MU_LOWER_UNICODE}: {round(player.rated_trueskill_mu, 1)}`, "
+                        f"`{SIGMA_LOWER_UNICODE}: {round(player.rated_trueskill_sigma, 1)}`)"
                     )
-                    description += f"\n{SIGMA_LOWER_UNICODE}: {round(player.rated_trueskill_sigma, 1)}"
                 else:
                     description = f"Rating: {trueskill_pct}"
                 cols = get_table_col(fgs)

--- a/discord_bots/cogs/common.py
+++ b/discord_bots/cogs/common.py
@@ -445,7 +445,7 @@ class CommonCommands(BaseCog):
                             embed=Embed(description="Could not find your stats")
                         )
                         return
-                    title = f"{category.name} TrueSkill Stats"
+                    title = f"TrueSkill for {category.name}"
                     if category.is_rated and SHOW_TRUESKILL:
                         description = (
                             f"Rating: **{round(pct.rank, 1)}**"

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -200,7 +200,7 @@ async def create_game(
         if len(player_ids) == 1:
             # Useful for debugging, no real world application
             players = session.query(Player).filter(Player.id == player_ids[0]).all()
-            win_prob = 0
+            win_prob = 0.0
         else:
             """
             # run get_even_teams in a separate process, so that it doesn't block the event loop
@@ -899,20 +899,17 @@ async def autosub(ctx: Context, member: Member = None):
     )
     for i, field in enumerate(embed.fields):
         # brute force iteration through the embed's fields until we find the original team0 and team1 embeds to update
-        if field.name == f"⬅️ {game.team0_name} ({round(100 * game.win_probability)}%)":
+        if field.name and game.team0_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"⬅️ {game.team0_name} ({round(100 * game.win_probability)}%)",
+                name=f"⬅️ {game.team0_name} ({round(100 * game.win_probability, 1)}%)",
                 value=team0_diff_vaules,
                 inline=True,
             )
-        if (
-            field.name
-            == f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability))}%)"
-        ):
+        if field.name and game.team1_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability))}%)",
+                name=f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%)",
                 value=team1_diff_values,
                 inline=True,
             )
@@ -1551,20 +1548,17 @@ async def sub(ctx: Context, member: Member):
     )
     for i, field in enumerate(embed.fields):
         # brute force iteration through the embed's fields until we find the original team0 and team1 embeds to update
-        if field.name == f"⬅️ {game.team0_name} ({round(100 * game.win_probability)}%)":
+        if field.name and game.team0_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"⬅️ {game.team0_name} ({round(100 * game.win_probability)}%)",
+                name=f"⬅️ {game.team0_name} ({round(100 * game.win_probability, 1)}%)",
                 value=team0_diff_vaules,
                 inline=True,
             )
-        if (
-            field.name
-            == f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability))}%)"
-        ):
+        if field.name and game.team1_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability))}%)",
+                name=f"➡️ {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%)",
                 value=team1_diff_values,
                 inline=True,
             )


### PR DESCRIPTION
- Condensed the format of `/stats` to make it a little more compact and readable
- Upped the rounding for the win probabilities of the teams back up to 1 digit
- Bolded the player names of the winning team to help improve readability
Examples:
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/0169cd7a-a502-4aac-91f2-4c98098e05fa)
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/6ed36257-fbb7-4802-abdd-2986280508ba)
