### PR TITLE
style: make game code embed field a code block

### DIFF
--- a/discord_bots/cogs/common.py
+++ b/discord_bots/cogs/common.py
@@ -142,6 +142,7 @@ class CommonCommands(BaseCog):
             await interaction.response.defer(ephemeral=True)
             title: str = f"Lobby code for ({short_uuid(ipg.id)})"
             if ipg.channel_id and ipg.message_id:
+                # Update the match channel's in_progress_game embed with the game code
                 partial_message = get_guild_partial_message(
                     interaction.guild, ipg.channel_id, ipg.message_id
                 )
@@ -158,7 +159,7 @@ class CommonCommands(BaseCog):
                                     embed.set_field_at(
                                         i,
                                         name="🔢 Game Code",
-                                        value=f"`{code}`",
+                                        value=code_block(code, language="yaml"),
                                         inline=True,
                                     )
                                     replaced_code = True

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -685,7 +685,11 @@ async def create_in_progress_game_embed(
     if game.channel_id:
         embed.add_field(name="📺 Channel", value=f"<#{game.channel_id}>", inline=True)
     if game.code:
-        embed.add_field(name="🔢 Game Code", value=f"`{game.code}`", inline=True)
+        embed.add_field(
+            name="🔢 Game Code",
+            value=code_block(game.code, language="yaml"),
+            inline=True,
+        )
     add_empty_field(embed, offset=3)
     return embed
 


### PR DESCRIPTION
Changed the game code field in the in progress game's embed to be a code block, so you can 1 click copy the code and add a bit of syntax highlighting for flavor:
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/4599e4de-b1b6-481b-b3c5-d9f65b17790f)
