### PR TITLE
fix: map autocomplete issue, setgamecode code block, move some commands to admin

### DIFF
--- a/discord_bots/cogs/raffle.py
+++ b/discord_bots/cogs/raffle.py
@@ -9,7 +9,7 @@ from sqlalchemy.sql import functions
 from discord_bots.checks import is_admin_app_command, is_command_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Map, Player, Rotation, RotationMap, Session
-from discord_bots.utils import map_autocomplete, rotation_autocomplete
+from discord_bots.utils import map_short_name_autocomplete, rotation_autocomplete
 
 strings = [
     "Don't give up!",
@@ -149,18 +149,18 @@ class RaffleCommands(BaseCog):
     @app_commands.check(is_command_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
-        map_name="Existing map",
+        map_short_name="Existing map",
         raffle_ticket_reward="Raffle award",
     )
     @app_commands.autocomplete(
-        rotation_name=rotation_autocomplete, map_name=map_autocomplete
+        rotation_name=rotation_autocomplete, map_short_name=map_short_name_autocomplete
     )
-    @app_commands.rename(rotation_name="rotation", map_name="map")
+    @app_commands.rename(rotation_name="rotation", map_short_name="map")
     async def setrotationmapraffle(
         self,
         interaction: Interaction,
         rotation_name: str,
-        map_name: str,
+        map_short_name: str,
         raffle_ticket_reward: int,
     ):
         """
@@ -182,14 +182,14 @@ class RaffleCommands(BaseCog):
                 session.query(RotationMap)
                 .join(Map, Map.id == RotationMap.map_id)
                 .join(Rotation, Rotation.id == RotationMap.rotation_id)
-                .filter(Map.short_name.ilike(map_name))
+                .filter(Map.short_name.ilike(map_short_name))
                 .filter(Rotation.name.ilike(rotation_name))
                 .first()  # type: ignore
             )
             if not rotation_map:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Could not find map **{map_name}** in rotation **{rotation_name}**",
+                        description=f"Could not find map **{map_short_name}** in rotation **{rotation_name}**",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,
@@ -201,7 +201,7 @@ class RaffleCommands(BaseCog):
 
             await interaction.response.send_message(
                 embed=Embed(
-                    description=f"Raffle tickets for **{map_name}** in **{rotation_name}** set to **{raffle_ticket_reward}**",
+                    description=f"Raffle tickets for **{map_short_name}** in **{rotation_name}** set to **{raffle_ticket_reward}**",
                     colour=Colour.blue(),
                 )
             )

--- a/discord_bots/cogs/rotation.py
+++ b/discord_bots/cogs/rotation.py
@@ -10,7 +10,7 @@ from discord_bots.checks import is_admin_app_command, is_command_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Map, Queue, Rotation, RotationMap, Session
 from discord_bots.utils import (
-    map_autocomplete,
+    map_short_name_autocomplete,
     rotation_autocomplete,
     update_next_map_to_map_after_next,
 )
@@ -64,18 +64,18 @@ class RotationCommands(BaseCog):
     @app_commands.check(is_command_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
-        map_name="Existing map",
+        map_short_name="Existing map",
         ordinal="Map ordinal",
     )
     @app_commands.autocomplete(
-        rotation_name=rotation_autocomplete, map_name=map_autocomplete
+        rotation_name=rotation_autocomplete, map_short_name=map_short_name_autocomplete
     )
-    @app_commands.rename(rotation_name="rotation", map_name="map")
+    @app_commands.rename(rotation_name="rotation", map_short_name="map")
     async def addrotationmap(
         self,
         interaction: Interaction,
         rotation_name: str,
-        map_name: str,
+        map_short_name: str,
         ordinal: int,
     ):
         """
@@ -110,11 +110,15 @@ class RotationCommands(BaseCog):
                 return
 
             try:
-                map = session.query(Map).filter(Map.short_name.ilike(map_name)).one()
+                map = (
+                    session.query(Map)
+                    .filter(Map.short_name.ilike(map_short_name))
+                    .one()
+                )
             except NoResultFound:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Could not find map **{map_name}**",
+                        description=f"Could not find map **{map_short_name}**",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,
@@ -152,7 +156,7 @@ class RotationCommands(BaseCog):
                 session.rollback()
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Error adding {map_name} to {rotation_name} at ordinal {ordinal}",
+                        description=f"Error adding {map_short_name} to {rotation_name} at ordinal {ordinal}",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,
@@ -209,12 +213,14 @@ class RotationCommands(BaseCog):
     @app_commands.check(is_admin_app_command)
     @app_commands.check(is_command_channel)
     @app_commands.autocomplete(
-        rotation_name=rotation_autocomplete, map_name=map_autocomplete
+        rotation_name=rotation_autocomplete, map_short_name=map_short_name_autocomplete
     )
-    @app_commands.rename(rotation_name="rotation", map_name="map")
-    @app_commands.describe(rotation_name="Existing rotation", map_name="Existing map")
+    @app_commands.rename(rotation_name="rotation", map_short_name="map")
+    @app_commands.describe(
+        rotation_name="Existing rotation", map_short_name="Existing map"
+    )
     async def removerotationmap(
-        self, interaction: Interaction, rotation_name: str, map_name: str
+        self, interaction: Interaction, rotation_name: str, map_short_name: str
     ):
         """
         Remove a map from a rotation
@@ -238,11 +244,15 @@ class RotationCommands(BaseCog):
                 return
 
             try:
-                map = session.query(Map).filter(Map.short_name.ilike(map_name)).one()
+                map = (
+                    session.query(Map)
+                    .filter(Map.short_name.ilike(map_short_name))
+                    .one()
+                )
             except NoResultFound:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Could not find map **{map_name}**",
+                        description=f"Could not find map **{map_short_name}**",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,
@@ -296,20 +306,20 @@ class RotationCommands(BaseCog):
     @app_commands.check(is_command_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
-        map_name="Existing map",
+        map_short_name="Existing map",
         new_ordinal="New map ordinal",
     )
     @app_commands.autocomplete(
-        rotation_name=rotation_autocomplete, map_name=map_autocomplete
+        rotation_name=rotation_autocomplete, map_short_name=map_short_name_autocomplete
     )
     @app_commands.rename(
-        rotation_name="rotation", map_name="map", new_ordinal="ordinal"
+        rotation_name="rotation", map_short_name="map", new_ordinal="ordinal"
     )
     async def setrotationmapordinal(
         self,
         interaction: Interaction,
         rotation_name: str,
-        map_name: str,
+        map_short_name: str,
         new_ordinal: int,
     ):
         """
@@ -344,11 +354,15 @@ class RotationCommands(BaseCog):
                 return
 
             try:
-                map = session.query(Map).filter(Map.short_name.ilike(map_name)).one()
+                map = (
+                    session.query(Map)
+                    .filter(Map.short_name.ilike(map_short_name))
+                    .one()
+                )
             except NoResultFound:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Could not find map **{map_name}**",
+                        description=f"Could not find map **{map_short_name}**",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,

--- a/discord_bots/cogs/vote.py
+++ b/discord_bots/cogs/vote.py
@@ -28,7 +28,7 @@ from discord_bots.models import (
     VotePassedWaitlist,
 )
 from discord_bots.utils import (
-    map_autocomplete,
+    map_short_name_autocomplete,
     queue_autocomplete,
     update_next_map_to_map_after_next,
 )
@@ -213,10 +213,10 @@ class VoteCommands(BaseCog):
     )
     @app_commands.check(is_command_channel)
     @app_commands.guild_only()
-    @app_commands.describe(map_name="Map to remove votes from")
-    @app_commands.rename(map_name="map")
-    @app_commands.autocomplete(map_name=map_autocomplete)
-    async def unvotemap(self, interaction: Interaction, map_name: str):
+    @app_commands.describe(map_short_name="Map to remove votes from")
+    @app_commands.rename(map_short_name="map")
+    @app_commands.autocomplete(map_short_name=map_short_name_autocomplete)
+    async def unvotemap(self, interaction: Interaction, map_short_name: str):
         """
         Remove all of a player's votes for a map
         Use irrespective of rotation/queue because that seems like a super niche use case
@@ -225,7 +225,7 @@ class VoteCommands(BaseCog):
         session: SQLAlchemySession
         with Session() as session:
             map: Map | None = (
-                session.query(Map).filter(Map.short_name.ilike(map_name)).first()
+                session.query(Map).filter(Map.short_name.ilike(map_short_name)).first()
             )
             if not map:
                 await interaction.response.send_message(
@@ -249,7 +249,7 @@ class VoteCommands(BaseCog):
             if not map_votes:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"You don't have any votes for {map_name}",
+                        description=f"You don't have any votes for {map_short_name}",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,
@@ -441,10 +441,16 @@ class VoteCommands(BaseCog):
 
     @group.command(name="map", description="Vote for a map in a queue")
     @app_commands.guild_only()
-    @app_commands.describe(queue_name="Name of the queue", map_name="Map to vote for")
-    @app_commands.rename(queue_name="queue", map_name="map")
-    @app_commands.autocomplete(queue_name=queue_autocomplete, map_name=map_autocomplete)
-    async def votemap(self, interaction: Interaction, queue_name: str, map_name: str):
+    @app_commands.describe(
+        queue_name="Name of the queue", map_short_name="Map to vote for"
+    )
+    @app_commands.rename(queue_name="queue", map_short_name="map")
+    @app_commands.autocomplete(
+        queue_name=queue_autocomplete, map_short_name=map_short_name_autocomplete
+    )
+    async def votemap(
+        self, interaction: Interaction, queue_name: str, map_short_name: str
+    ):
         """
         Vote for a map in a queue
         TODO: Vote for many maps at once
@@ -492,12 +498,12 @@ class VoteCommands(BaseCog):
                 return
 
             map: Map | None = (
-                session.query(Map).filter(Map.short_name.ilike(map_name)).first()
+                session.query(Map).filter(Map.short_name.ilike(map_short_name)).first()
             )
             if not map:
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Could not find map **{map_name}**",
+                        description=f"Could not find map **{map_short_name}**",
                         colour=Colour.red(),
                     ),
                     ephemeral=True,

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -1519,7 +1519,7 @@ def add_empty_field(embed: discord.Embed, *, offset: int = 0):
     return embed
 
 
-async def map_autocomplete(interaction: Interaction, current: str):
+async def map_short_name_autocomplete(interaction: Interaction, current: str):
     result = []
     session: SQLAlchemySession
     with Session() as session:


### PR DESCRIPTION
A few changes are included; `!sync` is required:
1. `/map changequeuemap` -> `/admin setqueuemap`
2. `/map changegamemap` -> `/admin setgamemap`
3. Fixed an issue where some commands were querying based on the map full name, while the autocomplete returned the shortname
4. Fixed the `/setgamecode` not using a code block for the code in the embed sent to DMs