### PR TITLE
fix: leaderboard, stats, and mapstats broken style

### DIFF
--- a/discord_bots/cogs/common.py
+++ b/discord_bots/cogs/common.py
@@ -366,6 +366,7 @@ class CommonCommands(BaseCog):
                 return cols
 
             embeds: list[Embed] = []
+            message_content = ""  # TODO: temp fix
             footer_text = f"Rating = {MU_LOWER_UNICODE} - 3*{SIGMA_LOWER_UNICODE}"
             cols = []
             conditions = []
@@ -401,8 +402,8 @@ class CommonCommands(BaseCog):
                     if category.is_rated and SHOW_TRUESKILL:
                         description = (
                             f"Rating: **{round(pct.rank, 1)}**"
-                            f" (`{MU_LOWER_UNICODE}: {round(pct.mu, 1)}`, "
-                            f"`{SIGMA_LOWER_UNICODE}: {round(pct.sigma, 1)}`)"
+                            f" `{MU_LOWER_UNICODE}: {round(pct.mu, 1)}`, "
+                            f"`{SIGMA_LOWER_UNICODE}: {round(pct.sigma, 1)}` "
                         )
                     else:
                         description = f"Rating: {trueskill_pct}"
@@ -429,8 +430,9 @@ class CommonCommands(BaseCog):
                     )
                     description += code_block(table)
                     embed = Embed(
-                        title=title, description=description, color=Colour.dark_theme()
+                        title=title, description=description, color=Colour.dark_embed()
                     )
+                    message_content += f"\n{title}\n{description}"  # TODO: temp fix
                     if i == (num_pct - 1):
                         # only add the footer to the last embed so we don't duplicate the information
                         embed.set_footer(text=footer_text)
@@ -442,8 +444,8 @@ class CommonCommands(BaseCog):
                     rank = player.rated_trueskill_mu - 3 * player.rated_trueskill_sigma
                     description = (
                         f"Rating: **{round(rank, 1)}**"
-                        f" (`{MU_LOWER_UNICODE}: {round(player.rated_trueskill_mu, 1)}`, "
-                        f"`{SIGMA_LOWER_UNICODE}: {round(player.rated_trueskill_sigma, 1)}`)"
+                        f" `{MU_LOWER_UNICODE}: {round(player.rated_trueskill_mu, 1)}`, "
+                        f"`{SIGMA_LOWER_UNICODE}: {round(player.rated_trueskill_sigma, 1)}` "
                     )
                 else:
                     description = f"Rating: {trueskill_pct}"
@@ -466,10 +468,16 @@ class CommonCommands(BaseCog):
                 embed = Embed(
                     title="Overall Stats",
                     description=description,
+                    color=Colour.dark_embed(),
                 )
                 embed.set_footer(text=footer_text)
                 embeds.append(embed)
+                message_content = (
+                    f"Overall Stats\n{description}\n{footer_text}"  # TODO: temp fix
+                )
             try:
-                await interaction.response.send_message(embeds=embeds, ephemeral=True)
+                await interaction.response.send_message(
+                    content=message_content, ephemeral=True
+                )
             except Exception:
                 _log.exception(f"Caught exception trying to send stats message")

--- a/discord_bots/cogs/map.py
+++ b/discord_bots/cogs/map.py
@@ -470,9 +470,12 @@ class MapCommands(BaseCog):
         else:
             title = f"{interaction.user.display_name} Overall Map Stats"
         embed = Embed(
-            title=title, description=code_block(table), colour=Colour.dark_theme()
+            title=title, description=code_block(table), colour=Colour.dark_embed()
         )
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        # await interaction.response.send_message(embed=embed, ephemeral=True)
+        await interaction.response.send_message(
+            content=f"{title}\n{code_block(table)}", ephemeral=True
+        )  # TODO: temp fix
 
     @group.command(
         name="globalstats", description="Displays global statistics for each map"

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1129,7 +1129,7 @@ async def status(ctx: Context, *args):
         ipg_embeds: list[Embed] = []
         rotation_queues: list[Queue] | None
         for rotation in all_rotations:
-            conditions = [Queue.rotation_id == rotation.id]
+            conditions = [Queue.rotation_id == rotation.id, Queue.is_locked == False]
             if queue_indices:
                 conditions.append(Queue.ordinal.in_(queue_indices))
             if queue_names:
@@ -1173,19 +1173,19 @@ async def status(ctx: Context, *args):
                     else config.DEFAULT_RAFFLE_VALUE
                 )
                 next_map_str += f" ({raffle_reward} tickets)"
-            embed.add_field(
-                name=f"",
-                # value="─"*10,
-                value=f"```asciidoc\n* {rotation.name}```",
-                inline=False,
-            )
-            embed.add_field(
-                name=f"🗺️ Next Map",
-                value=next_map_str,
-                inline=False,
-            )
-
             rotation_queues_len = len(rotation_queues)
+            if rotation_queues_len:
+                embed.add_field(
+                    name=f"",
+                    value=f"```asciidoc\n* {rotation.name}```",
+                    inline=False,
+                )
+                embed.add_field(
+                    name=f"🗺️ Next Map",
+                    value=next_map_str,
+                    inline=False,
+                )
+
             for i, queue in enumerate(rotation_queues):
                 if queue.is_locked:
                     continue

--- a/discord_bots/tasks.py
+++ b/discord_bots/tasks.py
@@ -300,7 +300,7 @@ async def afk_timer_task():
                 session.commit()
 
 
-@tasks.loop(seconds=1800)
+@tasks.loop(seconds=1)
 async def leaderboard_task():
     """
     Periodically print the leaderboard

--- a/discord_bots/views/configure_map.py
+++ b/discord_bots/views/configure_map.py
@@ -102,7 +102,7 @@ class MapConfigureView(BaseView):
                 if not self.map_id
                 else f'Editing Map "{self.full_name}" ({self.short_name})'
             ),
-            color=discord.Color.dark_theme(),
+            color=discord.Color.dark_embed(),
         )
         embed.add_field(
             name="Name", value=self.full_name if self.full_name else "*None*"


### PR DESCRIPTION
Since code blocks inside embeds are still broken, I went ahead and reworked the leaderboard, `/stats`/ and `/map stats`.
The leaderboard has come full circle and is basically the same as the old one, aside from some minor differences:
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/f7c86986-eef7-4b26-b9d9-db6ab961027d)
`/stats` I just threw inside of a regular message in the interim, but I'll be looking into some alternate formatting in the future
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/f3b9eec6-03d8-4388-a126-1d14aab8b86b)
`/map stats` (and `/map globalstats`) are the same, where they're just inside a regular message
![image](https://github.com/tribesonecommunity/discord-bots/assets/27743409/23e5f00d-5ac6-494b-82fb-f3c94aa65726)
