### PR TITLE
fix: del not removing player from queue_waitlist_player

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1045,6 +1045,8 @@ async def del_(ctx: Context, *args):
         embed_description += f"**{message.author.display_name}** removed from **{', '.join([queue.name for queue in queues_to_del])}**"
         embed.color = discord.Color.green()
     if queues_to_del_by_queue_waitlist_player:
+        if embed_description:
+            embed_description += "\n"
         embed_description += f"**{message.author.display_name}** removed from the waitlist for **{', '.join([queue.name for queue in queues_to_del_by_queue_waitlist_player])}**"
         embed.color = discord.Color.green()
     embed.description = embed_description

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1010,6 +1010,7 @@ async def del_(ctx: Context, *args):
         queues_to_del_query_by_queue_waitlist_player.all()
     )
 
+    queues_del_from_by_id: dict[int, Queue] = {}
     for queue in queues_to_del:
         session.query(QueuePlayer).filter(
             QueuePlayer.queue_id == queue.id, QueuePlayer.player_id == message.author.id
@@ -1034,20 +1035,17 @@ async def del_(ctx: Context, *args):
             ),
             inline=True,
         )
+        queues_del_from_by_id[queue.id] = queue
     for queue in queues_to_del_by_queue_waitlist_player:
         session.query(QueueWaitlistPlayer).filter(
             QueueWaitlistPlayer.queue_id == queue.id,
             QueueWaitlistPlayer.player_id == message.author.id,
         ).delete()
+        queues_del_from_by_id[queue.id] = queue
 
     embed_description = ""
-    if queues_to_del:
-        embed_description += f"**{message.author.display_name}** removed from **{', '.join([queue.name for queue in queues_to_del])}**"
-        embed.color = discord.Color.green()
-    if queues_to_del_by_queue_waitlist_player:
-        if embed_description:
-            embed_description += "\n"
-        embed_description += f"**{message.author.display_name}** removed from the waitlist for **{', '.join([queue.name for queue in queues_to_del_by_queue_waitlist_player])}**"
+    if queues_del_from_by_id:
+        embed_description += f"**{message.author.display_name}** removed from **{', '.join([queue.name for queue in queues_del_from_by_id.values()])}**"
         embed.color = discord.Color.green()
     embed.description = embed_description
     add_empty_field(embed)

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1050,7 +1050,7 @@ async def del_(ctx: Context, *args):
     embed.description = embed_description
     add_empty_field(embed)
     if embed.description:
-        await ctx.reply(embed=embed)
+        await message.channel.send(embed=embed)
     session.commit()
     session.close()
 

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1220,7 +1220,7 @@ async def status(ctx: Context, *args):
                     if players_in_queue
                     else []
                 )
-                newline = "\n,"  # Escape sequence (backslash) not allowed in expression portion of f-string prior to Python 3.12
+                newline = "\n"  # Escape sequence (backslash) not allowed in expression portion of f-string prior to Python 3.12
                 embed.add_field(
                     name=queue_title_str,
                     value=(

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -6,10 +6,9 @@ import math
 import os
 import statistics
 from datetime import datetime, timedelta, timezone
-from functools import lru_cache
 from heapq import heappop, heappush
 from itertools import combinations
-from typing import Optional
+from typing import List, Optional
 
 import discord
 import imgkit
@@ -33,7 +32,7 @@ from discord.utils import escape_markdown
 from PIL import Image
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 from table2ascii import Alignment, Merge, PresetStyle, table2ascii
 from trueskill import Rating, global_env
@@ -53,6 +52,8 @@ from discord_bots.models import (
     Player,
     PlayerCategoryTrueskill,
     Queue,
+    QueuePlayer,
+    QueueWaitlistPlayer,
     Rotation,
     RotationMap,
     Session,
@@ -1822,3 +1823,59 @@ async def command_autocomplete(interaction: Interaction, current: str):
                         )
                     )
     return result
+
+
+def del_player_from_queues_and_waitlists(
+    session: sqlalchemy.orm.Session, player_id: int, *args: str
+) -> list[Queue]:
+    queues_del_from_by_id: dict[str, Queue] = {}
+    if args:
+        # can be a mix of queue ordinals or names
+        conditions = [
+            or_(
+                Queue.ordinal.in_(args),
+                func.lower(Queue.name).in_([x.lower() for x in args]),
+            )
+        ]
+    else:
+        conditions = []
+    queues: List[Queue] = (
+        session.query(Queue)
+        .join(
+            QueuePlayer,
+            and_(
+                QueuePlayer.player_id == player_id,
+                QueuePlayer.queue_id == Queue.id,
+            ),
+        )
+        .filter(*conditions)
+        .order_by(Queue.ordinal.asc())
+        .all()
+    )
+    queues_by_queue_waitlist_player: List[Queue] = (
+        session.query(Queue)
+        .join(
+            QueueWaitlistPlayer,
+            and_(
+                QueueWaitlistPlayer.player_id == player_id,
+                QueueWaitlistPlayer.queue_id == Queue.id,
+            ),
+        )
+        .filter(*conditions)
+        .order_by(Queue.ordinal.asc())
+        .all()
+    )
+    for queue in queues:
+        session.query(QueuePlayer).filter(
+            QueuePlayer.queue_id == queue.id, QueuePlayer.player_id == player_id
+        ).delete()
+        queues_del_from_by_id[queue.id] = queue
+
+    for queue in queues_by_queue_waitlist_player:
+        session.query(QueueWaitlistPlayer).filter(
+            QueueWaitlistPlayer.queue_id == queue.id,
+            QueueWaitlistPlayer.player_id == player_id,
+        ).delete()
+        queues_del_from_by_id[queue.id] = queue
+
+    return list(queues_del_from_by_id.values())

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -1833,8 +1833,8 @@ def del_player_from_queues_and_waitlists(
         # can be a mix of queue ordinals or names
         conditions = [
             or_(
-                Queue.ordinal.in_(args),
-                func.lower(Queue.name).in_([x.lower() for x in args]),
+                Queue.ordinal.in_([arg for arg in args if arg.isdigit()]),
+                func.lower(Queue.name).in_([x.casefold() for x in args]),
             )
         ]
     else:

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -1833,7 +1833,9 @@ def del_player_from_queues_and_waitlists(
         # can be a mix of queue ordinals or names
         conditions = [
             or_(
-                Queue.ordinal.in_([arg for arg in args if arg.isdigit()]),
+                Queue.ordinal.in_(
+                    [arg for arg in args if all(char in "0123456789" for char in arg)]
+                ),
                 func.lower(Queue.name).in_([x.casefold() for x in args]),
             )
         ]


### PR DESCRIPTION
`del` will now remove the the appropriate queue_waitlist_player based on the args they pass in. The behavior is the same as it is for deleting from queues -- i.e., no target, ordinal as target, name as target, or a combination.

It's also worth noting that any negative case of using `del` (not in any queues, no valid queues specified, etc...) will now be ignored and no message is sent. It may be confusing to the user, but it's less spamy. The previous behavior always posted a message saying "no valid queues specified" which I felt like was both confusing and spamy.