### PR TITLE
Do not show map image on sub and autosub

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -842,7 +842,9 @@ async def autosub(ctx: Context, member: Member = None):
         colour=Colour.yellow(),
     )
     await _rebalance_game(game, session, message)
-    embed: discord.Embed = await create_in_progress_game_embed(session, game, guild)
+    embed: discord.Embed = await create_in_progress_game_embed(
+        session, game, guild, False
+    )
     short_game_id: str = short_uuid(game.id)
     embed.title = f"New Teams for Game {short_game_id})"
     embed.description = (
@@ -1457,7 +1459,9 @@ async def sub(ctx: Context, member: Member):
     )
 
     await _rebalance_game(game, session, message)
-    embed: discord.Embed = await create_in_progress_game_embed(session, game, guild)
+    embed: discord.Embed = await create_in_progress_game_embed(
+        session, game, guild, False
+    )
     short_game_id: str = short_uuid(game.id)
     embed.title = f"New Teams for Game {short_game_id})"
     embed.description = (

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -601,6 +601,7 @@ async def create_in_progress_game_embed(
     session: sqlalchemy.orm.Session,
     game: InProgressGame,
     guild: discord.Guild,
+    show_map_image: bool = True,
 ) -> Embed:
     queue: Queue | None = session.query(Queue).filter(Queue.id == game.queue_id).first()
     embed: discord.Embed
@@ -690,18 +691,19 @@ async def create_in_progress_game_embed(
             inline=True,
         )
     add_empty_field(embed, offset=3)
-    map: Map | None = (
-        session.query(Map)
-        .filter(
-            or_(
-                Map.full_name == game.map_full_name,
-                Map.short_name == game.map_short_name,
+    if show_map_image:
+        map: Map | None = (
+            session.query(Map)
+            .filter(
+                or_(
+                    Map.full_name == game.map_full_name,
+                    Map.short_name == game.map_short_name,
+                )
             )
+            .first()
         )
-        .first()
-    )
-    if map and map.image_url:
-        embed.set_image(url=map.image_url)
+        if map and map.image_url:
+            embed.set_image(url=map.image_url)
     return embed
 
 


### PR DESCRIPTION
Don't show the map image on sub/autosub, since the width of the image clamps the width of the embed, which can cause the code block to have undesirable word wrapping. This change improves readability