### PR TITLE
feat: allow configuring player skill volatility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,12 +135,10 @@ POP_RANDOM_QUEUE=
 
 #DEFAULT_TRUESKILL_MU=OPTIONAL_REPLACE_ME
 #DEFAULT_TRUESKILL_SIGMA=OPTIONAL_REPLACE_ME
+#DEFAULT_TRUESKILL_TAU=OPTIONAL_REPLACE_ME
 
 # Time in UTC at which the decay job will run each day
 #TRUESKILL_SIGMA_DECAY_JOB_SCHEDULED_TIME=00:00:00Z
-
-# Minimum sigma value. Set it higher to allow faster player movement
-# SIGMA_FLOOR=0
 
 #######################################################################
 # Leave the Twitch variables commented out unless you actually have   #

--- a/discord_bots/cogs/in_progress_game.py
+++ b/discord_bots/cogs/in_progress_game.py
@@ -25,6 +25,7 @@ from discord.ext import commands
 from discord.ui import Button, button
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 from trueskill import Rating, rate
+from trueskill import setup as trueskill_setup
 
 from discord_bots import config
 from discord_bots.checks import is_admin_app_command, is_command_channel
@@ -563,7 +564,6 @@ class InProgressGameCommands(commands.Cog):
         ):
             for i, team_gip in enumerate(team_players):
                 player = players_by_id[team_gip.player_id]
-                sigma_after = max(config.SIGMA_FLOOR, ratings_after[i].sigma)
                 finished_game_player = FinishedGamePlayer(
                     finished_game_id=finished_game.id,
                     player_id=player.id,
@@ -572,18 +572,18 @@ class InProgressGameCommands(commands.Cog):
                     rated_trueskill_mu_before=ratings_before[i].mu,
                     rated_trueskill_sigma_before=ratings_before[i].sigma,
                     rated_trueskill_mu_after=ratings_after[i].mu,
-                    rated_trueskill_sigma_after=sigma_after,
+                    rated_trueskill_sigma_after=ratings_after[i].sigma,
                 )
                 trueskill_rating = ratings_after[i]
                 # Regardless of category, always update the master trueskill. That way
                 # when we create new categories off of it the data isn't completely
                 # stale
                 player.rated_trueskill_mu = trueskill_rating.mu
-                player.rated_trueskill_sigma = sigma_after
+                player.rated_trueskill_sigma = trueskill_rating.sigma
                 if player.id in player_category_trueskills_by_id:
                     pct = player_category_trueskills_by_id[player.id]
                     pct.mu = trueskill_rating.mu
-                    pct.sigma = sigma_after
+                    pct.sigma = trueskill_rating.sigma
                     pct.rank = trueskill_rating.mu - 3 * trueskill_rating.sigma
                     pct.last_game_finished_at = game_finished_at
                 else:
@@ -592,7 +592,7 @@ class InProgressGameCommands(commands.Cog):
                             player_id=player.id,
                             category_id=queue.category_id,
                             mu=trueskill_rating.mu,
-                            sigma=sigma_after,
+                            sigma=trueskill_rating.sigma,
                             rank=trueskill_rating.mu - 3 * trueskill_rating.sigma,
                             last_game_finished_at=game_finished_at,
                         )

--- a/discord_bots/cogs/player.py
+++ b/discord_bots/cogs/player.py
@@ -400,7 +400,7 @@ class PlayerCommands(BaseCog):
                     ephemeral=True,
                 )
                 return
-            min_sigma = max(1.5, config.SIGMA_FLOOR)
+            min_sigma = 1.0
             max_sigma = min(8.33, config.DEFAULT_TRUESKILL_SIGMA)
             if sigma < min_sigma or sigma > max_sigma:
                 await interaction.response.send_message(

--- a/discord_bots/cogs/trueskill.py
+++ b/discord_bots/cogs/trueskill.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.checks import is_admin_app_command, is_command_channel
 from discord_bots.cogs.base import BaseCog
-from discord_bots.config import DEFAULT_TRUESKILL_MU, DEFAULT_TRUESKILL_SIGMA
+from discord_bots.config import (
+    DEFAULT_TRUESKILL_MU,
+    DEFAULT_TRUESKILL_SIGMA,
+    DEFAULT_TRUESKILL_TAU,
+)
 from discord_bots.models import Player, PlayerCategoryTrueskill, Queue, Session
 from discord_bots.utils import mean, print_leaderboard
 
@@ -26,8 +30,9 @@ class TrueskillCommands(BaseCog):
     @app_commands.check(is_command_channel)
     async def trueskill(self, interaction: Interaction):
         output = ""
-        output += "**mu (μ)**: The average skill of the gamer"
-        output += "\n**sigma (σ)**: The degree of uncertainty in the gamer's skill"
+        output += f"**mu (μ)**: The average skill of the gamer (default: {DEFAULT_TRUESKILL_MU:.1f})\n"
+        output += f"\n**sigma (σ)**: The degree of uncertainty in the gamer's skill (default: {DEFAULT_TRUESKILL_SIGMA:.1f})\n"
+        output += f'\n**tau (τ)**: The "dynamics" factor, greater values increase player position volatility (default: {DEFAULT_TRUESKILL_TAU:.1f})\n'
         output += "\n**Reference**: https://www.microsoft.com/en-us/research/project/trueskill-ranking-system"
         output += "\n**Implementation**: https://trueskill.org/"
         thumbnail = "https://www.microsoft.com/en-us/research/uploads/prod/2016/02/trueskill-skilldia.jpg"

--- a/discord_bots/config.py
+++ b/discord_bots/config.py
@@ -178,6 +178,9 @@ DEFAULT_TRUESKILL_MU: float = _to_float(key="DEFAULT_TRUESKILL_MU", default=25)
 DEFAULT_TRUESKILL_SIGMA: float = _to_float(
     key="DEFAULT_TRUESKILL_SIGMA", default=DEFAULT_TRUESKILL_MU / 3
 )
+DEFAULT_TRUESKILL_TAU: float = _to_float(
+    key="DEFAULT_TRUESKILL_TAU", default=DEFAULT_TRUESKILL_SIGMA / 100
+)
 DEFAULT_TRUESKILL_BETA: float = DEFAULT_TRUESKILL_SIGMA / 2
 TRUESKILL_SIGMA_DECAY_JOB_SCHEDULED_TIME: datetime.time = _to_time(key="TRUESKILL_SIGMA_DECAY_JOB_SCHEDULED_TIME", default=datetime.time(0, 0, tzinfo=datetime.timezone.utc))
 AFK_TIME_MINUTES: int = _to_int(key="AFK_TIME_MINUTES", default=45)
@@ -203,8 +206,5 @@ GAME_HISTORY_CHANNEL: int = _to_int(key="GAME_HISTORY_CHANNEL", required=True)
 ADMIN_AUTOSUB: bool = _to_bool(key="ADMIN_AUTOSUB", default=False)
 POP_RANDOM_QUEUE: bool = _to_bool(key="POP_RANDOM_QUEUE", default=False)
 MM_SIGMA_MULT: float = _to_float(key="MM_SIGMA_MULT", default=0)
-
-# The lowest sigma floor value a player can have
-SIGMA_FLOOR: float = _to_float(key="SIGMA_FLOOR", default=1.5)
 
 # TODO grouping here and in docs

--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -7,6 +7,7 @@ from discord import Colour, Embed, Interaction, Member, Message, Reaction
 from discord.abc import User
 from discord.app_commands import AppCommandError, errors
 from discord.ext.commands import CommandError, Context, UserInputError
+from trueskill import setup as trueskill_setup
 
 import discord_bots.config as config
 from discord_bots.cogs.admin import AdminCommands
@@ -280,6 +281,11 @@ async def setup():
     if config.ECONOMY_ENABLED:
         prediction_task.start()
     sigma_decay_task.start()
+    trueskill_setup(
+        mu=config.DEFAULT_TRUESKILL_MU,
+        sigma=config.DEFAULT_TRUESKILL_SIGMA,
+        tau=config.DEFAULT_TRUESKILL_TAU,
+    )
 
 
 async def main():


### PR DESCRIPTION
This adds a config to control `trueskill_tau`, which controls how much player skill moves between games. The default value for tau is `sigma / 100`. 

In my testing, setting a tau value of 0.5 (default is 0.083), sigma seem to settle around ~2.75-3. So since sigma ends up a little higher, players do move around more.

Thanks to @StephenBartos for pointing out tau to me :)

Here's a screenshot example - I set my player sigma to 2.7, then mocked a game and lost it even though the expected outcome was a loss. The outcome sigma for me was 2.71, so it went up even though I lost an expected game, which I'm attributing to the tau value being much higher than the default:

Expected loss:
![image](https://github.com/user-attachments/assets/fbc28fb8-d8d3-4ab8-be4d-acd95b09bf3d)

Tau goes up from 2.7:
![image](https://github.com/user-attachments/assets/5813e636-0f3e-48f5-a72e-dd68fce714e9)

updated trueskill info:
![image](https://github.com/user-attachments/assets/a1504b46-e364-4213-aff2-093bee97dd63)


