### PR TITLE
fix: fix hash in migration

### DIFF
--- a/alembic/versions/20250607181932_54080d3503e2_make_role_id_bigint.py
+++ b/alembic/versions/20250607181932_54080d3503e2_make_role_id_bigint.py
@@ -1,6 +1,6 @@
 """Make role_id bigint
 
-Revision ID: 54080d3503e2
+Revision ID: 4aa167bcf1b8
 Revises: e64a149b226f
 Create Date: 2025-06-07 18:19:32.272390
 


### PR DESCRIPTION
the t1 db state was bad due to converting from sqlite, and while fixing it i created a temp migration that wasn't committed to the repo. this migration in this pr refers to that temp migration that's not committed.

this tries to fix the issue by manually changing the hash it points to