### PR TITLE
fix: force dockerfile to use python3.12 and to use pre-compiled binaries to speed up build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM debian:stable-slim as debinstall
+FROM python:3.12-slim as debinstall
 SHELL [ "/bin/bash", "-c" ]
 RUN apt-get update
 
@@ -9,8 +9,7 @@ RUN apt-get update
 # this may be a quirk specific to Docker containers. This is why I've
 # split it into multiple apt-gets here.
 
-RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install python3 python3-venv python3-pip python3-dev
-RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install g++ make vim
+RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install python3-venv python3-dev
 RUN --mount=type=cache,uid=0,gid=0,target=/var/cache/apt apt-get --yes install libpq-dev libjpeg-dev libffi-dev g++ make vim
 
 FROM debinstall as usersetup
@@ -25,13 +24,13 @@ COPY setup.py .
 COPY startup.sh .
 RUN python3 -m venv .venv
 ENV PATH=".venv/bin:$PATH"
-RUN pip install --upgrade pip
-RUN --mount=type=cache,uid=999,gid=999,target=/tribesbot/.cache/pip pip install -U .
+RUN pip install --upgrade pip wheel
+RUN --mount=type=cache,uid=999,gid=999,target=/tribesbot/.cache/pip pip install --prefer-binary -U .
 
 FROM requirements as base
 # remove unnecessary packages from the image after everything has been built
 USER root
-RUN apt-get --yes autoremove python3-venv python3-dev libffi-dev g++ make python3-pip python3-dev
+RUN apt-get --yes autoremove python3-venv python3-dev libffi-dev g++ make python3-pip
 
 FROM base as build
 WORKDIR /tribesbot


### PR DESCRIPTION
Python3.13 has issues with some dependencies, so until I have more time to debug them, I'm forcing 3.12