### PR TITLE
Captain pick mode: channel scoping

### DIFF
--- a/discord_bots/checks.py
+++ b/discord_bots/checks.py
@@ -5,10 +5,35 @@ from discord import Colour, Embed, Interaction, Member, Message
 from discord.ext.commands.context import Context
 
 from discord_bots.utils import send_message
-from . import config
 
+from . import config
 from .config import CHANNEL_ID, ECONOMY_ENABLED
-from .models import AdminRole, Player, Session
+from .models import AdminRole, Config, Player, Session
+
+_captain_channel_id_cache: int | None = None
+_captain_channel_id_cache_loaded: bool = False
+
+
+def _load_captain_channel_id_cache() -> None:
+    global _captain_channel_id_cache, _captain_channel_id_cache_loaded
+    with Session() as session:
+        config_row = session.query(Config).first()
+        _captain_channel_id_cache = (
+            config_row.captain_channel_id if config_row else None
+        )
+    _captain_channel_id_cache_loaded = True
+
+
+def get_cached_captain_channel_id() -> int | None:
+    if not _captain_channel_id_cache_loaded:
+        _load_captain_channel_id_cache()
+    return _captain_channel_id_cache
+
+
+def update_captain_channel_id_cache(value: int | None) -> None:
+    global _captain_channel_id_cache, _captain_channel_id_cache_loaded
+    _captain_channel_id_cache = value
+    _captain_channel_id_cache_loaded = True
 
 
 def __has_admin_role(user_id: int, member: Member) -> bool:
@@ -154,6 +179,30 @@ async def is_command_channel(interaction: Interaction) -> bool:
         return False
     else:
         return True
+
+
+async def is_command_or_captain_channel(interaction: Interaction) -> bool:
+    """
+    Check that interactions are performed from the command channel or the
+    registered captain pick channel (Config.captain_channel_id).
+    """
+    if interaction.channel:
+        captain_channel_id = get_cached_captain_channel_id()
+        if interaction.channel.id == CHANNEL_ID or (
+            captain_channel_id is not None
+            and interaction.channel.id == captain_channel_id
+        ):
+            return True
+
+    description = "Interactions must be performed from the command channel"
+    if get_cached_captain_channel_id() is not None:
+        description += " or the captain channel"
+    embed = Embed(description=description, colour=Colour.red())
+    if not interaction.response.is_done():
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+    else:
+        await interaction.followup.send(embed=embed, ephemeral=True)
+    return False
 
 
 class HasName(Protocol):

--- a/discord_bots/cogs/admin.py
+++ b/discord_bots/cogs/admin.py
@@ -19,7 +19,7 @@ from discord_bots.async_db_utils import (
     async_session,
 )
 from discord_bots.bot import bot
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.cogs.in_progress_game import InProgressGameCommands
 from discord_bots.models import (
@@ -85,7 +85,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="add", description="Add an admin")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be made admin")
     async def addadmin(self, interaction: Interaction, member: Member):
         session: SQLAlchemySession
@@ -128,7 +128,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="addrole", description="Add an admin role")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(role="Role to be made admin")
     async def addadminrole(self, interaction: Interaction, role: Role):
         if interaction.guild:
@@ -168,7 +168,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="ban", description="Bans player from queues")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be banned")
     async def ban(self, interaction: Interaction, member: Member):
         async with async_session() as session:
@@ -250,7 +250,7 @@ class AdminCommands(BaseCog):
         name="configure", description="Initially configure the bot for this server"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def configure(self, interaction: Interaction):
         assert interaction.guild
@@ -284,7 +284,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(description="Create or Edit a custom command")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(name="New or Existing command name")
     @app_commands.autocomplete(name=command_autocomplete)
     async def customcommand(self, interaction: Interaction, name: str):
@@ -298,7 +298,7 @@ class AdminCommands(BaseCog):
         name="createdbbackup", description="Creates a backup of the database"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def createdbbackup(self, interaction: Interaction):
         # Only functions for SQLite
         # TODO: Covert to work for Postgres
@@ -326,7 +326,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="deletegame", description="Deletes a finished game")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="Finished game id")
     async def deletegame(self, interaction: Interaction, game_id: str):
         session: SQLAlchemySession
@@ -361,7 +361,7 @@ class AdminCommands(BaseCog):
         name="delplayer", description="Admin command to delete player from all queues"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be removed from queues")
     async def delplayer(
         self,
@@ -411,7 +411,7 @@ class AdminCommands(BaseCog):
         name="editgamewinner", description="Edit the winner of a finished game"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="Finished game id", outcome="Tie, BE, DS")
     async def editgamewinner(
         self,
@@ -465,7 +465,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="remove", description="Remove an admin")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be removed as admin")
     async def removeadmin(self, interaction: Interaction, member: Member):
         session: SQLAlchemySession
@@ -491,7 +491,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="removerole", description="Remove an admin role")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     @app_commands.describe(role="Role to be removed as admin")
     async def removeadminrole(self, interaction: Interaction, role: Role):
@@ -534,7 +534,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="removecommand", description="Remove a custom command")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(name="Name of existing custom command")
     @app_commands.autocomplete(name=command_autocomplete)
     async def removecommand(self, interaction: Interaction, name: str):
@@ -568,7 +568,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="removedbbackup", description="Remove a database backup")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(db_filename="Name of backup file")
     async def removedbbackup(self, interaction: Interaction, db_filename: str):
         # Only functions for SQLite
@@ -619,7 +619,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="restart", description="Restart the bot")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def restart(self, interaction: Interaction):
         await interaction.response.send_message(
             embed=Embed(
@@ -631,7 +631,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="setbias", description="Set team bias")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Member to bias", amount="Bias value")
     async def setbias(self, interaction: Interaction, member: Member, amount: float):
         if amount < -100 or amount > 100:
@@ -652,7 +652,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="setcaptainbias", description="Set captain bias")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Member to bias", amount="Bias value")
     async def setcaptainbias(
         self, interaction: Interaction, member: Member, amount: float
@@ -677,7 +677,7 @@ class AdminCommands(BaseCog):
         name="setcommandprefix", description="Sets the prefix for context commands"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(prefix="New command prefix")
     async def setcommandprefix(self, interaction: Interaction, prefix: str):
         # TODO move to db-config
@@ -692,7 +692,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="unban", description="Unban player")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be unbanned")
     async def unban(self, interaction: Interaction, member: Member):
         async with async_session() as session:
@@ -745,7 +745,7 @@ class AdminCommands(BaseCog):
     @admin_group.command(
         name="resetleaderboard", description="Resets & updates the leaderboards"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.check(is_admin_app_command)
     async def resetleaderboardchannel(self, interaction: Interaction):
         if not config.LEADERBOARD_CHANNEL:
@@ -785,7 +785,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(description="Set the map for a game")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="In progress game id", map_short_name="Map name")
     @app_commands.autocomplete(
         game_id=in_progress_game_autocomplete,
@@ -854,7 +854,7 @@ class AdminCommands(BaseCog):
         description="Set the map for a queue (note: affects all queues sharing the same rotation)",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Queue Name", map_short_name="Map Name")
     @app_commands.rename(queue_name="queue", map_short_name="map")
     @app_commands.autocomplete(
@@ -937,7 +937,7 @@ class AdminCommands(BaseCog):
 
     @admin_group.command(name="cancel", description="Cancels the specified game")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="The game ID")
     @app_commands.autocomplete(game_id=in_progress_game_autocomplete)
     @app_commands.rename(game_id="game")

--- a/discord_bots/cogs/category.py
+++ b/discord_bots/cogs/category.py
@@ -5,10 +5,10 @@ from discord.ext.commands import Bot
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Category, PlayerCategoryTrueskill, Queue, Session
-from discord_bots.utils import default_sigma_decay_amount, build_category_str
+from discord_bots.utils import build_category_str, default_sigma_decay_amount
 from discord_bots.views.configure_category import CategoryConfigureView
 
 _log = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ class CategoryCommands(BaseCog):
 
     @group.command(name="configure", description="Create/Edit a category")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(category_name="New or existing category")
     async def configure(self, interaction: Interaction, category_name: str):
         assert interaction.guild
@@ -79,7 +79,7 @@ class CategoryCommands(BaseCog):
 
     @group.command(name="remove", description="Remove an existing category")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(name="Category to be removed")
     @app_commands.rename(name="category")
     async def removecategory(self, interaction: Interaction, name: str):
@@ -111,7 +111,7 @@ class CategoryCommands(BaseCog):
             session.commit()
 
     @group.command(name="show", description="Show category details")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(category_name="Existing category")
     @app_commands.rename(category_name="category")
     async def showcategory(self, interaction: Interaction, category_name: str):

--- a/discord_bots/cogs/common.py
+++ b/discord_bots/cogs/common.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 from table2ascii import Alignment, PresetStyle, table2ascii
 from trueskill import Rating
 
-from discord_bots.checks import is_command_channel
+from discord_bots.checks import is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.config import SHOW_TRUESKILL
 from discord_bots.models import (
@@ -49,7 +49,7 @@ class CommonCommands(BaseCog):
     @app_commands.command(
         name="setgamecode", description="Sets lobby code for your current game"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     @app_commands.describe(code="Game lobby code")
     async def setgamecode(self, interaction: Interaction, code: str):
@@ -197,7 +197,7 @@ class CommonCommands(BaseCog):
     @app_commands.command(
         name="stats", description="Privately displays your TrueSkill statistics"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(category_name="Category to show stats for")
     @app_commands.autocomplete(category_name=category_autocomplete_with_user_id)
     @app_commands.rename(category_name="category")

--- a/discord_bots/cogs/config.py
+++ b/discord_bots/cogs/config.py
@@ -7,7 +7,7 @@ import discord_bots.config as env_config
 from discord_bots.bot import bot
 from discord_bots.checks import (
     is_admin_app_command,
-    is_command_channel,
+    is_command_or_captain_channel,
     update_captain_channel_id_cache,
 )
 from discord_bots.models import Config, Session
@@ -25,7 +25,7 @@ class ConfigCommands(commands.Cog):
         name="setdefaultmu", description="Set the default mu for new players"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def setdefaultmu(self, interaction: Interaction, value: float):
         """
         Set the default mu for new players
@@ -48,7 +48,7 @@ class ConfigCommands(commands.Cog):
         name="setdefaultsigma", description="Set the default sigma for new players"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def setdefaultsigma(self, interaction: Interaction, value: float):
         """
         Set the default sigma for new players
@@ -70,7 +70,7 @@ class ConfigCommands(commands.Cog):
         name="setdefaulttau", description="Set the default tau for new players"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def setdefaulttau(self, interaction: Interaction, value: float):
         """
         Set the default tau for new players
@@ -91,7 +91,7 @@ class ConfigCommands(commands.Cog):
 
     @group.command(name="list", description="List current configuration values")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listconfig(self, interaction: Interaction):
         """
         List current configuration values
@@ -141,7 +141,7 @@ class ConfigCommands(commands.Cog):
         description="Enable/disable position-based trueskill",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(option="True/False")
     async def togglepositiontrueskill(self, interaction: Interaction, option: bool):
         """
@@ -169,7 +169,7 @@ class ConfigCommands(commands.Cog):
         description="Enable/disable map-based trueskill",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(option="True/False")
     async def togglemaptrueskill(self, interaction: Interaction, option: bool):
         """
@@ -197,7 +197,7 @@ class ConfigCommands(commands.Cog):
         description="Register a channel as the captain pick lobby",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(channel="Channel to register as the captain pick lobby")
     async def setcaptainchannel(self, interaction: Interaction, channel: TextChannel):
         with Session() as session:
@@ -225,7 +225,7 @@ class ConfigCommands(commands.Cog):
         description="Unregister the captain pick lobby channel",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def clearcaptainchannel(self, interaction: Interaction):
         with Session() as session:
             config = session.query(Config).first()

--- a/discord_bots/cogs/config.py
+++ b/discord_bots/cogs/config.py
@@ -5,7 +5,11 @@ from discord.ext import commands
 
 import discord_bots.config as env_config
 from discord_bots.bot import bot
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import (
+    is_admin_app_command,
+    is_command_channel,
+    update_captain_channel_id_cache,
+)
 from discord_bots.models import Config, Session
 
 _log = logging.getLogger(__name__)
@@ -119,6 +123,16 @@ class ConfigCommands(commands.Cog):
                 value=f"`{config.enable_position_trueskill}`",
                 inline=True,
             )
+            captain_channel_value = (
+                f"<#{config.captain_channel_id}>"
+                if config.captain_channel_id
+                else "`Not set`"
+            )
+            embed.add_field(
+                name="Captain channel",
+                value=captain_channel_value,
+                inline=True,
+            )
 
             await interaction.response.send_message(embed=embed)
 
@@ -177,3 +191,54 @@ class ConfigCommands(commands.Cog):
                 admin_log_channel = bot.get_channel(env_config.ADMIN_LOG_CHANNEL)
                 if isinstance(admin_log_channel, TextChannel):
                     await admin_log_channel.send(embed=embed)
+
+    @group.command(
+        name="setcaptainchannel",
+        description="Register a channel as the captain pick lobby",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_command_channel)
+    @app_commands.describe(channel="Channel to register as the captain pick lobby")
+    async def setcaptainchannel(self, interaction: Interaction, channel: TextChannel):
+        with Session() as session:
+            config = session.query(Config).first()
+            config.captain_channel_id = channel.id
+            session.commit()
+        update_captain_channel_id_cache(channel.id)
+
+        embed = Embed(
+            description=(
+                f"Captain channel set to {channel.mention} by "
+                f"<@{interaction.user.id}>. New queues created in that channel "
+                f"will be captain-pick queues."
+            ),
+            colour=Colour.green(),
+        )
+        await interaction.response.send_message(embed=embed)
+        if env_config.ADMIN_LOG_CHANNEL:
+            admin_log_channel = bot.get_channel(env_config.ADMIN_LOG_CHANNEL)
+            if isinstance(admin_log_channel, TextChannel):
+                await admin_log_channel.send(embed=embed)
+
+    @group.command(
+        name="clearcaptainchannel",
+        description="Unregister the captain pick lobby channel",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_command_channel)
+    async def clearcaptainchannel(self, interaction: Interaction):
+        with Session() as session:
+            config = session.query(Config).first()
+            config.captain_channel_id = None
+            session.commit()
+        update_captain_channel_id_cache(None)
+
+        embed = Embed(
+            description=f"Captain channel cleared by <@{interaction.user.id}>",
+            colour=Colour.green(),
+        )
+        await interaction.response.send_message(embed=embed)
+        if env_config.ADMIN_LOG_CHANNEL:
+            admin_log_channel = bot.get_channel(env_config.ADMIN_LOG_CHANNEL)
+            if isinstance(admin_log_channel, TextChannel):
+                await admin_log_channel.send(embed=embed)

--- a/discord_bots/cogs/economy.py
+++ b/discord_bots/cogs/economy.py
@@ -1,13 +1,9 @@
 import logging
 from datetime import datetime, timedelta, timezone
 from operator import itemgetter
-from pytz import utc
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.session import Session as SQLAlchemySession
 from typing import Any, Literal, Optional
 
 from discord import (
-    app_commands,
     ButtonStyle,
     Client,
     Colour,
@@ -17,17 +13,21 @@ from discord import (
     TextChannel,
     TextStyle,
     VoiceChannel,
+    app_commands,
 )
 from discord.ext.commands import Bot
 from discord.member import Member
 from discord.ui import Button, Modal, TextInput, View
 from discord.utils import get
+from pytz import utc
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.bot import bot
 from discord_bots.checks import (
     economy_enabled,
     is_admin_app_command,
-    is_command_channel,
+    is_command_or_captain_channel,
 )
 from discord_bots.cogs.base import BaseCog
 from discord_bots.config import (
@@ -89,7 +89,7 @@ class EconomyCommands(BaseCog):
     @group.command(name="add", description=f"Admin; Add {CURRENCY_NAME} to a player")
     @app_commands.check(economy_enabled)
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Discord member", add_value="Currency to be added")
     async def addcurrency(
         self, interaction: Interaction, member: Member, add_value: int
@@ -442,7 +442,7 @@ class EconomyCommands(BaseCog):
         name="donate", description=f"Donate {CURRENCY_NAME} to another player"
     )
     @app_commands.check(economy_enabled)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         member="Discord member", donation_value="Currency value to donate"
     )
@@ -785,7 +785,7 @@ class EconomyCommands(BaseCog):
 
     @group.command(name="show", description=f"Show how many {CURRENCY_NAME} you have")
     @app_commands.check(economy_enabled)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def showcurrency(self, interaction: Interaction):
         session: SQLAlchemySession
         with Session() as session:

--- a/discord_bots/cogs/in_progress_game.py
+++ b/discord_bots/cogs/in_progress_game.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 from trueskill import Rating, rate
 
 from discord_bots import config
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.economy import EconomyCommands
 from discord_bots.models import (
     Category,
@@ -275,7 +275,7 @@ class InProgressGameCommands(commands.Cog):
         name="history",
         description="Privately displays your game history",
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def gamehistory(self, interaction: Interaction, count: int):
         assert interaction.guild
@@ -341,7 +341,7 @@ class InProgressGameCommands(commands.Cog):
             )
 
     @group.command(name="finish", description="Ends the current game you are in")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(outcome="win, loss, or tie")
     @app_commands.guild_only()
     async def finishgame(
@@ -696,7 +696,7 @@ class InProgressGameCommands(commands.Cog):
     )
     @app_commands.guild_only()
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.autocomplete(game_id=in_progress_game_autocomplete)
     @app_commands.rename(game_id="game")
     async def movegameplayers(self, interaction: Interaction, game_id: str):
@@ -733,7 +733,7 @@ class InProgressGameCommands(commands.Cog):
                 )
 
     @group.command(name="show", description="Show game details")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="Finished game id")
     async def showgame(self, interaction: Interaction, game_id: str):
         session: SQLAlchemySession
@@ -763,7 +763,7 @@ class InProgressGameCommands(commands.Cog):
 
     @group.command(name="showdebug", description="Show game details")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(game_id="Finished game id")
     async def showgamedebug(self, interaction: Interaction, game_id: str):
         player_id = interaction.user.id

--- a/discord_bots/cogs/list.py
+++ b/discord_bots/cogs/list.py
@@ -7,7 +7,7 @@ from discord.utils import escape_markdown
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.bot import bot
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.config import DB_NAME
 from discord_bots.models import (
@@ -34,7 +34,7 @@ class ListCommands(BaseCog):
     group = app_commands.Group(name="list", description="List commands")
 
     @group.command(name="admin", description="List admin users")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listadmins(self, interaction: Interaction):
         output = "Admins:"
         session: SQLAlchemySession
@@ -49,7 +49,7 @@ class ListCommands(BaseCog):
         )
 
     @group.command(name="adminrole", description="List admin roles")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listadminroles(self, interaction: Interaction):
         output = "Admin roles:"
         session: SQLAlchemySession
@@ -77,7 +77,7 @@ class ListCommands(BaseCog):
         )
 
     @group.command(name="ban", description="List banned players")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listbans(self, interaction: Interaction):
         output = "Bans:"
         session: SQLAlchemySession
@@ -93,7 +93,7 @@ class ListCommands(BaseCog):
         )
 
     @group.command(name="category", description="List categories")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listcategories(self, interaction: Interaction):
         session: SQLAlchemySession
         with Session() as session:
@@ -119,7 +119,7 @@ class ListCommands(BaseCog):
 
     @group.command(name="channel", description="List bot channels")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listchannels(self, interaction: Interaction):
         for channel in bot.get_all_channels():
             _log.info(channel.id, channel)  # DEBUG, TRACE?
@@ -134,7 +134,7 @@ class ListCommands(BaseCog):
 
     @group.command(name="dbbackup", description="List database backups")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listdbbackups(self, interaction: Interaction):
         output = "Backups:"
         for filename in glob(f"{DB_NAME}_*.db"):
@@ -149,7 +149,7 @@ class ListCommands(BaseCog):
         )
 
     @group.command(name="map", description="List all maps in the map pool")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listmaps(self, interaction: Interaction):
         """
         List all maps in the map pool
@@ -174,7 +174,7 @@ class ListCommands(BaseCog):
             )
 
     @group.command(name="notification", description="List your notifications")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listnotifications(self, interaction: Interaction):
         output = "Queue notifications:"
         session: SQLAlchemySession
@@ -205,7 +205,7 @@ class ListCommands(BaseCog):
     @group.command(
         name="queue", description="List all queues with their category and rotation"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listqueues(self, interaction: Interaction):
         """
         List all queues with their category and rotation
@@ -264,7 +264,7 @@ class ListCommands(BaseCog):
         name="queuerole",
         description="List all queues and their associated discord roles",
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listqueueroles(self, interaction: Interaction):
         """
         List all queues and their associated discord roles
@@ -298,7 +298,7 @@ class ListCommands(BaseCog):
     @group.command(
         name="rotation", description="List all rotations in the rotation pool"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def listrotations(self, interaction: Interaction):
         """
         List all rotations in the rotation pool

--- a/discord_bots/cogs/map.py
+++ b/discord_bots/cogs/map.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 from table2ascii import Alignment, PresetStyle, table2ascii
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import (
     Category,
@@ -146,7 +146,7 @@ class MapCommands(BaseCog):
 
     @group.command(name="configure", description="Create or Edit a map")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(map_full_name="New or existing map")
     @app_commands.autocomplete(map_full_name=map_full_name_autocomplete)
     @app_commands.rename(map_full_name="map")
@@ -175,7 +175,7 @@ class MapCommands(BaseCog):
 
     @group.command(name="remove", description="Remove a map from the map pool")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(map_short_name="Short name of map")
     @app_commands.autocomplete(map_short_name=map_short_name_autocomplete)
     @app_commands.rename(map_short_name="map")

--- a/discord_bots/cogs/notification.py
+++ b/discord_bots/cogs/notification.py
@@ -4,7 +4,7 @@ from discord import Colour, Embed, Interaction, app_commands
 from discord.ext.commands import Bot
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_command_channel
+from discord_bots.checks import is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Queue, QueueNotification, Session
 from discord_bots.utils import queue_autocomplete
@@ -22,7 +22,7 @@ class NotificationCommands(BaseCog):
         name="queue",
         description="Get DM when a queue reaches the specified number of players. You will only be notified once.",
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Queue name",
         size="A one-time notification will be sent when the queue reaches this number of players",
@@ -69,7 +69,7 @@ class NotificationCommands(BaseCog):
             session.commit()
 
     @group.command(name="remove", description="Remove all your notifications")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def removenotifications(self, interaction: Interaction):
         session: SQLAlchemySession
         with Session() as session:

--- a/discord_bots/cogs/player.py
+++ b/discord_bots/cogs/player.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql import select
 
 from discord_bots import config
 from discord_bots.bot import bot
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.config import ENABLE_VOICE_MOVE, LEADERBOARD_CHANNEL
 from discord_bots.models import (
@@ -33,7 +33,7 @@ class PlayerCommands(BaseCog):
     group = app_commands.Group(name="player", description="Player commands")
 
     @group.command(name="commend", description="Commend player")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be commended")
     async def commend(self, interaction: Interaction, member: Member):
         session: SQLAlchemySession
@@ -156,7 +156,7 @@ class PlayerCommands(BaseCog):
             )
 
     @group.command(name="commendstats", description="Show commend stats")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def commendstats(self, interaction: Interaction):
         session: SQLAlchemySession
         with Session() as session:
@@ -224,7 +224,7 @@ class PlayerCommands(BaseCog):
     @group.command(
         name="toggleleaderboard", description="Enable/disable showing on leaderbaord"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(option="True/False")
     async def toggleleaderboard(self, interaction: Interaction, option: bool):
         session: SQLAlchemySession
@@ -262,7 +262,7 @@ class PlayerCommands(BaseCog):
             )
 
     @group.command(name="togglestats", description="Enable/disable player stats")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(option="True/False")
     async def togglestats(self, interaction: Interaction, option: bool):
         session: SQLAlchemySession
@@ -300,7 +300,7 @@ class PlayerCommands(BaseCog):
             )
 
     @group.command(name="togglevoicemove", description="Enable/disable voice movement")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(option="True/False")
     async def togglevoicemove(self, interaction: Interaction, option: bool):
         if not ENABLE_VOICE_MOVE:
@@ -349,7 +349,7 @@ class PlayerCommands(BaseCog):
             )
 
     @group.command(name="setmu", description="Directly set a player's mu")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.check(is_admin_app_command)
     @app_commands.describe(member="Player to be adjusted", mu="Mu value")
     async def setmu(self, interaction: Interaction, member: Member, mu: float):
@@ -389,7 +389,7 @@ class PlayerCommands(BaseCog):
                     await admin_log_channel.send(embed=embed)
 
     @group.command(name="setsigma", description="Directly set a player's sigma")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.check(is_admin_app_command)
     @app_commands.describe(member="Player to be adjusted", sigma="Sigma value")
     async def setsigma(self, interaction: Interaction, member: Member, sigma: float):

--- a/discord_bots/cogs/position.py
+++ b/discord_bots/cogs/position.py
@@ -6,7 +6,7 @@ from discord.ext.commands import Bot
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Position, Session
 
@@ -39,7 +39,7 @@ class PositionCommands(BaseCog):
 
     @group.command(name="add", description="Add a new position")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(name="Name of the position")
     @app_commands.describe(short_name="Short hand name of the position")
     async def add(self, interaction: Interaction, name: str, short_name: str):
@@ -70,7 +70,7 @@ class PositionCommands(BaseCog):
 
     @group.command(name="remove", description="Remove a position")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(name="Name of the position")
     @app_commands.autocomplete(name=position_autocomplete)
     async def remove(self, interaction: Interaction, name: str):

--- a/discord_bots/cogs/queue.py
+++ b/discord_bots/cogs/queue.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.checks import (
     is_admin_app_command,
-    is_command_channel,
+    is_command_or_captain_channel,
     is_mock_user_app_command,
 )
 from discord_bots.cogs.base import BaseCog
@@ -62,7 +62,7 @@ class QueueCommands(BaseCog):
         name="role", description="Associate a discord role with a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", role="Discord role")
     async def addqueuerole(self, interaction: Interaction, queue_name: str, role: Role):
         """
@@ -103,7 +103,7 @@ class QueueCommands(BaseCog):
 
     @clear_group.command(name="category", description="Remove category from queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of existing queue")
     async def clearqueuecategory(self, interaction: Interaction, queue_name: str):
         session: SQLAlchemySession
@@ -133,7 +133,7 @@ class QueueCommands(BaseCog):
 
     @clear_group.command(name="players", description="Clear all players out of a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def clearqueue(self, interaction: Interaction, queue_name: str):
         """
@@ -166,7 +166,7 @@ class QueueCommands(BaseCog):
         name="range", description="Clear the Trueskill Rank range for a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def clearqueuerange(self, interaction: Interaction, queue_name: str):
         """
@@ -196,7 +196,7 @@ class QueueCommands(BaseCog):
 
     @queue_group.command(name="create", description="Create a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", size="Size of queue")
     async def createqueue(self, interaction: Interaction, queue_name: str, size: int):
         """
@@ -228,7 +228,7 @@ class QueueCommands(BaseCog):
 
     @queue_group.command(name="isolate", description="Isolate a queue (no auto-adds)")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def isolatequeue(self, interaction: Interaction, queue_name: str):
         """
@@ -259,7 +259,7 @@ class QueueCommands(BaseCog):
         name="lock", description="Prevent players from adding to a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def lockqueue(self, interaction: Interaction, queue_name: str):
         """
@@ -294,7 +294,7 @@ class QueueCommands(BaseCog):
         description="Helper test method for adding random players to queues",
     )
     @app_commands.check(is_mock_user_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", count="Number of people to add")
     async def mockqueue(self, interaction: Interaction, queue_name: str, count: int):
         """
@@ -353,7 +353,7 @@ class QueueCommands(BaseCog):
 
     @queue_group.command(name="remove", description="Remove a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def removequeue(self, interaction: Interaction, queue_name: str):
         """
@@ -399,7 +399,7 @@ class QueueCommands(BaseCog):
         name="removerole", description="Remove a discord role from a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", role="Discord role")
     async def removequeuerole(
         self, interaction: Interaction, queue_name: str, role: Role
@@ -463,7 +463,7 @@ class QueueCommands(BaseCog):
         name="category", description="Configure the category of a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Existing queue", category_name="Existing category"
     )
@@ -514,7 +514,7 @@ class QueueCommands(BaseCog):
         description="Set how much currency is awarded for games in queue",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Name of queue", award="Currency value to be awarded"
     )
@@ -564,7 +564,7 @@ class QueueCommands(BaseCog):
         description="Enables automatic moving of people in game when queue pops",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Name of queue", enabled_option="Is queue move enabled"
     )
@@ -617,7 +617,7 @@ class QueueCommands(BaseCog):
 
     @config_group.command(name="name", description="Set queue name")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         old_queue_name="Name of existing queue", new_queue_name="New name of queue"
     )
@@ -631,7 +631,7 @@ class QueueCommands(BaseCog):
 
     @config_group.command(name="ordinal", description="Set queue ordinal")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", ordinal="Queue ordinal")
     async def setqueueordinal(
         self, interaction: Interaction, queue_name: str, ordinal: int
@@ -664,7 +664,7 @@ class QueueCommands(BaseCog):
         name="range", description="Configure the Trueskill Rank range for a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Name of queue", min="Minimum Rank", max="Maximum Rank"
     )
@@ -700,7 +700,7 @@ class QueueCommands(BaseCog):
         name="rotation", description="Assign a map rotation to a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", rotation_name="Name of rotation")
     async def setqueuerotation(
         self, interaction: Interaction, queue_name: str, rotation_name: str
@@ -752,7 +752,7 @@ class QueueCommands(BaseCog):
         description="Set the number of players to pop a queue.  Also updates queue vote threshold.",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", queue_size="Queue size")
     async def setqueuesize(
         self, interaction: Interaction, queue_name: str, queue_size: int
@@ -787,7 +787,7 @@ class QueueCommands(BaseCog):
 
     # @group.command(name="setsweaty", description="Make a queue sweaty")
     # @app_commands.check(is_admin_app_command)
-    # @app_commands.check(is_command_channel)
+    # @app_commands.check(is_command_or_captain_channel)
     # @app_commands.describe(queue_name="Name of queue")
     # async def setqueuesweaty(self, interaction: Interaction, queue_name: str):
     #     """
@@ -818,7 +818,7 @@ class QueueCommands(BaseCog):
         name="votethreshold", description="Set the vote threshold for a queue"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", vote_threshold="Vote threshold")
     async def setqueuevotethreshold(
         self, interaction: Interaction, queue_name: str, vote_threshold: int
@@ -851,7 +851,7 @@ class QueueCommands(BaseCog):
             )
 
     @show_group.command(name="range", description="Displays the mu range")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def showqueuerange(self, interaction: Interaction, queue_name: str):
         """
@@ -877,7 +877,7 @@ class QueueCommands(BaseCog):
             )
 
     @show_group.command(name="rotation", description="Displays the map rotation")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def showqueuerotation(self, interaction: Interaction, queue_name: str):
         """
@@ -976,7 +976,7 @@ class QueueCommands(BaseCog):
         description="Unisolate a queue (rated, map rotation, auto-adds)",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def unisolatequeue(self, interaction: Interaction, queue_name: str):
         """
@@ -1005,7 +1005,7 @@ class QueueCommands(BaseCog):
 
     @queue_group.command(name="unlock", description="Allow players to add to a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def unlockqueue(self, interaction: Interaction, queue_name: str):
         """
@@ -1037,7 +1037,7 @@ class QueueCommands(BaseCog):
 
     # @group.command(name="unsetsweaty", description="Make a queue not sweaty")
     # @app_commands.check(is_admin_app_command)
-    # @app_commands.check(is_command_channel)
+    # @app_commands.check(is_command_or_captain_channel)
     # @app_commands.describe(queue_name="Name of queue")
     # async def unsetqueuesweaty(self, interaction: Interaction, queue_name: str):
     #     """
@@ -1069,7 +1069,7 @@ class QueueCommands(BaseCog):
         description="Enable/disable map-based trueskill for this queue",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def togglemaptrueskill(
         self, interaction: Interaction, queue_name: str, option: bool

--- a/discord_bots/cogs/queue.py
+++ b/discord_bots/cogs/queue.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.checks import (
+    get_cached_captain_channel_id,
     is_admin_app_command,
     is_command_or_captain_channel,
     is_mock_user_app_command,
@@ -200,19 +201,57 @@ class QueueCommands(BaseCog):
     @app_commands.describe(queue_name="Name of queue", size="Size of queue")
     async def createqueue(self, interaction: Interaction, queue_name: str, size: int):
         """
-        Create a queue
+        Create a queue. Queues created from the registered captain channel
+        are flagged as captain-pick automatically.
         """
+        captain_channel_id = get_cached_captain_channel_id()
+        is_captain_pick = (
+            captain_channel_id is not None
+            and interaction.channel is not None
+            and interaction.channel.id == captain_channel_id
+        )
+        if is_captain_pick:
+            if size < 4:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=(
+                            "Captain pick queues must have a size of at least 4 "
+                            "(two captains plus at least two picks)."
+                        ),
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            if size % 2 != 0:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description="Captain pick queues must have an even size.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
         vote_threshold: int = round(float(size) * 2 / 3)
-        queue = Queue(name=queue_name, size=size, vote_threshold=vote_threshold)
+        queue = Queue(
+            name=queue_name,
+            size=size,
+            vote_threshold=vote_threshold,
+            is_captain_pick=is_captain_pick,
+        )
 
         session: SQLAlchemySession
         with Session() as session:
             try:
                 session.add(queue)
                 session.commit()
+                description = f"Queue created: {queue.name}"
+                if is_captain_pick:
+                    description += " (captain pick)"
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Queue created: {queue.name}",
+                        description=description,
                         colour=Colour.green(),
                     )
                 )

--- a/discord_bots/cogs/queue_position.py
+++ b/discord_bots/cogs/queue_position.py
@@ -4,7 +4,7 @@ from discord import Colour, Embed, Interaction, app_commands
 from discord.ext.commands import Bot
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.cogs.position import PositionCommands
 from discord_bots.cogs.queue import QueueCommands
@@ -23,7 +23,7 @@ class QueuePositionCommands(BaseCog):
 
     @group.command(name="add", description="Add a position to a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Name of queue",
         position_name="Name of position",
@@ -97,7 +97,7 @@ class QueuePositionCommands(BaseCog):
 
     @group.command(name="update", description="Update a position's count in a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         queue_name="Name of queue",
         position_name="Name of position",
@@ -166,7 +166,7 @@ class QueuePositionCommands(BaseCog):
 
     @group.command(name="remove", description="Remove a position from a queue")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue", position_name="Name of position")
     @app_commands.autocomplete(queue_name=QueueCommands.queue_autocomplete)
     @app_commands.autocomplete(position_name=PositionCommands.position_autocomplete)
@@ -230,7 +230,7 @@ class QueuePositionCommands(BaseCog):
             )
 
     @group.command(name="list", description="List positions for a queue")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     @app_commands.autocomplete(queue_name=QueueCommands.queue_autocomplete)
     async def listqueuepositions(self, interaction: Interaction, queue_name: str):

--- a/discord_bots/cogs/raffle.py
+++ b/discord_bots/cogs/raffle.py
@@ -6,7 +6,7 @@ from emoji import emojize
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 from sqlalchemy.sql import functions
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Map, Player, Rotation, RotationMap, Session
 from discord_bots.utils import map_short_name_autocomplete, rotation_autocomplete
@@ -74,7 +74,7 @@ class RaffleCommands(BaseCog):
     @group.command(
         name="showtickets", description="Displays how many raffle tickets you have"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Discord member")
     async def myraffle(self, interaction: Interaction, *, member: Member | None = None):
         """
@@ -104,7 +104,7 @@ class RaffleCommands(BaseCog):
         name="status",
         description="Displays raffle ticket information and raffle leaderboard",
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Discord member")
     async def rafflestatus(
         self, interaction: Interaction, *, member: Member | None = None
@@ -146,7 +146,7 @@ class RaffleCommands(BaseCog):
         description="Set the raffle ticket reward for a map in a rotation",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         map_short_name="Existing map",
@@ -208,7 +208,7 @@ class RaffleCommands(BaseCog):
 
     @group.command(name="create", description="TODO: Implementation")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Discord member")
     async def createraffle(
         self, interaction: Interaction, *, member: Member | None = None
@@ -220,7 +220,7 @@ class RaffleCommands(BaseCog):
 
     @group.command(name="run", description="TODO: Implementation")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Discord member")
     async def runraffle(
         self, interaction: Interaction, *, member: Member | None = None

--- a/discord_bots/cogs/random.py
+++ b/discord_bots/cogs/random.py
@@ -5,7 +5,7 @@ from random import randint, random
 from discord import Colour, Embed, Interaction, app_commands
 from discord.ext.commands import Bot
 
-from discord_bots.checks import is_command_channel
+from discord_bots.checks import is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 
 _log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ class RandomCommands(BaseCog):
     group = app_commands.Group(name="random", description="Random commands")
 
     @group.command(name="coinflip", description="Flip a coin")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def coinflip(self, interaction: Interaction):
         result = "HEADS" if floor(random() * 2) == 0 else "TAILS"
         await interaction.response.send_message(
@@ -29,7 +29,7 @@ class RandomCommands(BaseCog):
         )
 
     @group.command(name="roll", description="Roll a random number")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(low_range="Minimum roll", high_range="Maximum roll")
     async def roll(self, interaction: Interaction, low_range: int, high_range: int):
         await interaction.response.send_message(

--- a/discord_bots/cogs/rotation.py
+++ b/discord_bots/cogs/rotation.py
@@ -8,9 +8,9 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
-from discord_bots.models import Map, Rotation, RotationMap, Session, RotationMapHistory
+from discord_bots.models import Map, Rotation, RotationMap, RotationMapHistory, Session
 from discord_bots.utils import (
     execute_map_rotation,
     map_short_name_autocomplete,
@@ -30,7 +30,7 @@ class RotationCommands(BaseCog):
 
     @group.command(name="add", description="Add a rotation to the rotation pool")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(rotation_name="Existing rotation")
     @app_commands.autocomplete(rotation_name=rotation_autocomplete)
     @app_commands.rename(rotation_name="rotation")
@@ -65,7 +65,7 @@ class RotationCommands(BaseCog):
         description="Add a map to a rotation at a specific ordinal (position)",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         map_short_name="Existing map",
@@ -192,7 +192,7 @@ class RotationCommands(BaseCog):
         name="remove", description="Remove a rotation from the rotation pool"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(rotation_name="Existing rotation")
     @app_commands.autocomplete(rotation_name=rotation_autocomplete)
     @app_commands.rename(rotation_name="rotation")
@@ -230,7 +230,7 @@ class RotationCommands(BaseCog):
 
     @group.command(name="removemap", description="Remove a map from a rotation")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.autocomplete(
         rotation_name=rotation_autocomplete, map_short_name=map_short_name_autocomplete
     )
@@ -322,7 +322,7 @@ class RotationCommands(BaseCog):
         description="Set the ordinal (position) for a map in a rotation",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         map_short_name="Existing map",
@@ -452,7 +452,7 @@ class RotationCommands(BaseCog):
         description="Set the random weight for a map in a rotation",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         map_short_name="Existing map",
@@ -551,7 +551,7 @@ class RotationCommands(BaseCog):
         description="Whether to stop auto-rotation when reaching this map",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         map_short_name="Existing map",
@@ -633,7 +633,7 @@ class RotationCommands(BaseCog):
 
     @group.command(name="setname", description="Set rotation name")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.autocomplete(old_rotation_name=rotation_autocomplete)
     @app_commands.rename(old_rotation_name="old_name", new_rotation_name="new_name")
     @app_commands.describe(
@@ -649,7 +649,7 @@ class RotationCommands(BaseCog):
 
     @group.command(name="configure-random", description="Configures the rotations random map properties")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         is_random="Whether to chooses rotation's maps at random",
@@ -708,7 +708,7 @@ class RotationCommands(BaseCog):
 
     @group.command(name="show-history", description="Shows the history of selected maps")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(
         rotation_name="Existing rotation",
         limit=f"How many entries to show. Max: {_show_rotation_limit}",

--- a/discord_bots/cogs/schedule.py
+++ b/discord_bots/cogs/schedule.py
@@ -1,15 +1,11 @@
 import asyncio
 import logging
-import pytz
 import re
 from datetime import date, datetime, time, timedelta
-from sqlalchemy import func
-from sqlalchemy.exc import IntegrityError
 
 import discord
-
+import pytz
 from discord import (
-    app_commands,
     ButtonStyle,
     Client,
     Colour,
@@ -20,13 +16,16 @@ from discord import (
     SelectOption,
     TextChannel,
     TextStyle,
+    app_commands,
 )
 from discord.ext.commands import Bot
 from discord.ui import Button, Select, TextInput, View
 from discord.utils import get
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 
 import discord_bots.config as config
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import (
     DiscordChannel,
@@ -69,7 +68,7 @@ class ScheduleCommands(BaseCog):
         description="Create a daily schedule for up to three times",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def createschedule(self, interaction: Interaction):
         """
@@ -100,7 +99,7 @@ class ScheduleCommands(BaseCog):
 
     @group.command(name="deleteschedule", description="Delete the schedule")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def deleteschedule(self, interaction: Interaction):
         """

--- a/discord_bots/cogs/trueskill.py
+++ b/discord_bots/cogs/trueskill.py
@@ -7,7 +7,7 @@ from discord.ext.commands import Bot
 from discord.utils import escape_markdown
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
-from discord_bots.checks import is_admin_app_command, is_command_channel
+from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import Config, Player, PlayerCategoryTrueskill, Queue, Session
 from discord_bots.utils import mean, print_leaderboard
@@ -22,7 +22,7 @@ class TrueskillCommands(BaseCog):
     group = app_commands.Group(name="trueskill", description="Trueskill commands")
 
     @group.command(name="info", description="Explanation of Trueskill")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def trueskill(self, interaction: Interaction):
         with Session() as session:
             config = session.query(Config).first()
@@ -42,7 +42,7 @@ class TrueskillCommands(BaseCog):
         name="resetplayer", description="Resets a players trueskill values to default"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Player to be reset")
     async def resetplayertrueskill(self, interaction: Interaction, member: Member):
         session: SQLAlchemySession
@@ -84,7 +84,7 @@ class TrueskillCommands(BaseCog):
 
     @group.command(name="showsigma", description="Returns the player's base sigma")
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(member="Existing player")
     async def showsigma(self, interaction: Interaction, member: Member):
         """
@@ -122,7 +122,7 @@ class TrueskillCommands(BaseCog):
         description="Print the normal distribution of the trueskill in a given queue",
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.describe(queue_name="Name of queue")
     async def showtrueskillnormdist(self, interaction: Interaction, queue_name: str):
         """
@@ -186,7 +186,7 @@ class TrueskillCommands(BaseCog):
         )
 
     @group.command(name="testleaderboard", description="Test print the leaderboard")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     async def testleaderboard(self, interaction: Interaction):
         await print_leaderboard()
 

--- a/discord_bots/cogs/vote.py
+++ b/discord_bots/cogs/vote.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 import discord_bots.config as config
 from discord_bots.checks import (
     is_admin_app_command,
-    is_command_channel,
+    is_command_or_captain_channel,
     is_mock_user_app_command,
 )
 from discord_bots.cogs.base import BaseCog
@@ -53,7 +53,7 @@ class VoteCommands(BaseCog):
         name="setmapthreshold", description="Set the number of votes required to pass"
     )
     @app_commands.check(is_admin_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     @app_commands.describe(threshold="Number of votes required")
     async def setmapvotethreshold(self, interaction: Interaction, threshold: int):
@@ -75,7 +75,7 @@ class VoteCommands(BaseCog):
         name="skipgamemap",
         description="Vote to skip to the next map for an in-progress game",
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def skipgamemap(self, interaction: Interaction):
         """
@@ -238,7 +238,7 @@ class VoteCommands(BaseCog):
                 )
 
     @group.command(name="unvote", description="Remove all of a player's votes")
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def unvote(self, interaction: Interaction):
         """
@@ -264,7 +264,7 @@ class VoteCommands(BaseCog):
     @group.command(
         name="unvotemap", description="Remove all of a player's votes for a map"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     @app_commands.describe(map_short_name="Map to remove votes from")
     @app_commands.rename(map_short_name="map")
@@ -322,7 +322,7 @@ class VoteCommands(BaseCog):
     @group.command(
         name="unskip", description="Remove all of a player's votes to skip the next map"
     )
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     async def unvoteskip(self, interaction: Interaction):
         """
@@ -358,7 +358,7 @@ class VoteCommands(BaseCog):
 
     @group.command(name="mock", description="Generates 6 mock votes for testing")
     @app_commands.check(is_mock_user_app_command)
-    @app_commands.check(is_command_channel)
+    @app_commands.check(is_command_or_captain_channel)
     @app_commands.guild_only()
     @app_commands.describe(
         type="Map: Mocks MapVote for first rotation_map | skip: Mocks SkipMapVote for first rotation",

--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -16,6 +16,7 @@ from discord_bots.async_db_utils import (
     async_query_first,
     async_session,
 )
+from discord_bots.checks import get_cached_captain_channel_id
 from discord_bots.cogs.admin import AdminCommands
 from discord_bots.cogs.category import CategoryCommands
 from discord_bots.cogs.common import CommonCommands
@@ -186,8 +187,14 @@ async def on_message(message: Message):
             await message.channel.send(content="\n".join(content))
             return
 
-    if (config.CHANNEL_ID and message.channel.id == config.CHANNEL_ID) or (
-        config.LEADERBOARD_CHANNEL and message.channel.id == config.LEADERBOARD_CHANNEL
+    captain_channel_id = get_cached_captain_channel_id()
+    if (
+        (config.CHANNEL_ID and message.channel.id == config.CHANNEL_ID)
+        or (
+            config.LEADERBOARD_CHANNEL
+            and message.channel.id == config.LEADERBOARD_CHANNEL
+        )
+        or (captain_channel_id is not None and message.channel.id == captain_channel_id)
     ):
         async with async_session() as session:
             player: Player | None = await async_query_first(


### PR DESCRIPTION
## Summary

Stacked on #166 (now merged). Adds the channel-scoping infrastructure for captain pick mode.

- New \`is_command_or_captain_channel\` check that accepts either the main command channel or the registered captain channel.
- Module-level cache for \`captain_channel_id\` so the on_message hot path doesn't hit the DB on every message. Lazily loaded on first read, invalidated on slash-command writes.
- \`/config setcaptainchannel\` and \`/config clearcaptainchannel\` admin slash commands.
- \`/config list\` now shows the captain channel.
- \`main.py:on_message\` accepts prefix commands (\`!add\`, \`!status\`, etc.) from the captain channel.
- Wholesale swap of \`is_command_channel\` → \`is_command_or_captain_channel\` on every cog. Admin commands are still gated by \`is_admin_app_command\`; letting them run from either channel is just a UX win.

The \`is_command_channel\` primitive remains defined in \`checks.py\` for any future case where a command needs to be locked to the main channel only.

## Test plan

- [ ] Bot starts cleanly with the new code
- [ ] \`/config setcaptainchannel #some-channel\` registers the channel
- [ ] \`/config list\` shows the captain channel
- [ ] After registration, \`!add\`, \`!status\`, etc. work in the captain channel
- [ ] Without registration (\`captain_channel_id\` NULL), behaviour matches pre-PR exactly

## Follow-ups

Next stacked PR: auto-flag queues created in the captain channel as captain-pick.