### PR TITLE
Captain pick mode: auto-flag queues in captain channel

### DIFF
--- a/discord_bots/cogs/queue.py
+++ b/discord_bots/cogs/queue.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.checks import (
+    get_cached_captain_channel_id,
     is_admin_app_command,
     is_command_or_captain_channel,
     is_mock_user_app_command,
@@ -200,19 +201,57 @@ class QueueCommands(BaseCog):
     @app_commands.describe(queue_name="Name of queue", size="Size of queue")
     async def createqueue(self, interaction: Interaction, queue_name: str, size: int):
         """
-        Create a queue
+        Create a queue. Queues created from the registered captain channel
+        are flagged as captain-pick automatically.
         """
+        captain_channel_id = get_cached_captain_channel_id()
+        is_captain_pick = (
+            captain_channel_id is not None
+            and interaction.channel is not None
+            and interaction.channel.id == captain_channel_id
+        )
+        if is_captain_pick:
+            if size < 4:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=(
+                            "Captain pick queues must have a size of at least 4 "
+                            "(two captains plus at least two picks)."
+                        ),
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            if size % 2 != 0:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description="Captain pick queues must have an even size.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
         vote_threshold: int = round(float(size) * 2 / 3)
-        queue = Queue(name=queue_name, size=size, vote_threshold=vote_threshold)
+        queue = Queue(
+            name=queue_name,
+            size=size,
+            vote_threshold=vote_threshold,
+            is_captain_pick=is_captain_pick,
+        )
 
         session: SQLAlchemySession
         with Session() as session:
             try:
                 session.add(queue)
                 session.commit()
+                description = f"Queue created: {queue.name}"
+                if is_captain_pick:
+                    description += " (captain pick)"
                 await interaction.response.send_message(
                     embed=Embed(
-                        description=f"Queue created: {queue.name}",
+                        description=description,
                         colour=Colour.green(),
                     )
                 )


### PR DESCRIPTION
## Summary

Stacked on #167. When \`/queue create\` is invoked from the registered captain channel, the new queue is automatically flagged as captain-pick.

- Queues created in the captain channel: \`is_captain_pick=True\`, validated size >= 4 and size % 2 == 0.
- Queues created in the main command channel: unchanged (\`is_captain_pick=False\`).
- Success message says "(captain pick)" when applicable.

The flag is set implicitly by creation channel — there's no separate admin command to toggle it, by design (per the plan in #166).

## Test plan

- [ ] \`/queue create foo 10\` from main channel → traditional queue, no validation change
- [ ] \`/queue create captainfoo 10\` from captain channel → captain-pick queue, success message reflects it
- [ ] \`/queue create cap 3\` from captain channel → rejected (size < 4)
- [ ] \`/queue create cap 5\` from captain channel → rejected (odd size)
- [ ] \`/queue create cap 8\` from captain channel → captain-pick queue created