### PR TITLE
Captain pick mode: channel-aware queue filtering

### DIFF
--- a/discord_bots/checks.py
+++ b/discord_bots/checks.py
@@ -36,6 +36,17 @@ def update_captain_channel_id_cache(value: int | None) -> None:
     _captain_channel_id_cache_loaded = True
 
 
+def queue_is_captain_pick_for_channel(channel_id: int) -> bool:
+    """
+    Whether queues visible from `channel_id` should be captain-pick queues.
+    True if `channel_id` is the registered captain channel; False otherwise.
+    Use this to derive a Queue.is_captain_pick filter from the invocation
+    channel.
+    """
+    captain_channel_id = get_cached_captain_channel_id()
+    return captain_channel_id is not None and channel_id == captain_channel_id
+
+
 def __has_admin_role(user_id: int, member: Member) -> bool:
     session: sqlalchemy.orm.Session
     with Session() as session:

--- a/discord_bots/cogs/list.py
+++ b/discord_bots/cogs/list.py
@@ -7,7 +7,11 @@ from discord.utils import escape_markdown
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.bot import bot
-from discord_bots.checks import is_admin_app_command, is_command_or_captain_channel
+from discord_bots.checks import (
+    is_admin_app_command,
+    is_command_or_captain_channel,
+    queue_is_captain_pick_for_channel,
+)
 from discord_bots.cogs.base import BaseCog
 from discord_bots.config import DB_NAME
 from discord_bots.models import (
@@ -212,7 +216,14 @@ class ListCommands(BaseCog):
         """
         session: SQLAlchemySession
         with Session() as session:
-            queues: list[Queue] | None = session.query(Queue).all()
+            queues: list[Queue] | None = (
+                session.query(Queue)
+                .filter(
+                    Queue.is_captain_pick
+                    == queue_is_captain_pick_for_channel(interaction.channel_id)
+                )
+                .all()
+            )
             if not queues:
                 await interaction.response.send_message(
                     embed=Embed(

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -32,7 +32,7 @@ from sqlalchemy.orm.session import Session as SQLAlchemySession
 from trueskill import Rating
 
 import discord_bots.config as config
-from discord_bots.checks import is_admin
+from discord_bots.checks import is_admin, queue_is_captain_pick_for_channel
 from discord_bots.utils import (
     add_empty_field,
     create_condensed_in_progress_game_embed,
@@ -680,6 +680,7 @@ async def add(ctx: Context, *args):
         .first()
     )
 
+    is_captain_channel = queue_is_captain_pick_for_channel(message.channel.id)
     queues_to_add: list[Queue] = []
     if len(args) == 0:
         if config.REQUIRE_ADD_TARGET:
@@ -693,14 +694,21 @@ async def add(ctx: Context, *args):
         # Don't auto-add to isolated queues
         queues_to_add += (
             session.query(Queue)
-            .filter(Queue.is_isolated == False, Queue.is_locked == False)
+            .filter(
+                Queue.is_isolated == False,
+                Queue.is_locked == False,
+                Queue.is_captain_pick == is_captain_channel,
+            )
             .order_by(Queue.ordinal.asc())
             .all()
         )  # type: ignore
     else:
         all_queues = (
             session.query(Queue)
-            .filter(Queue.is_locked == False)
+            .filter(
+                Queue.is_locked == False,
+                Queue.is_captain_pick == is_captain_channel,
+            )
             .order_by(Queue.ordinal.asc())
             .all()
         )  # type: ignore
@@ -714,7 +722,14 @@ async def add(ctx: Context, *args):
                 for queue_to_add in queues_with_ordinal:
                     queues_to_add.append(queue_to_add)
             except ValueError:
-                queue: Queue | None = session.query(Queue).filter(Queue.name.ilike(arg)).first()  # type: ignore
+                queue: Queue | None = (
+                    session.query(Queue)
+                    .filter(
+                        Queue.name.ilike(arg),
+                        Queue.is_captain_pick == is_captain_channel,
+                    )
+                    .first()
+                )  # type: ignore
                 if queue:
                     queues_to_add.append(queue)
             except IndexError:
@@ -1173,11 +1188,16 @@ async def status(ctx: Context, *args):
             await ctx.channel.send("No Rotations")
             return
 
+        is_captain_channel = queue_is_captain_pick_for_channel(ctx.channel.id)
         embed = Embed(title="Queues", color=Colour.blue())
         ipg_embeds: list[Embed] = []
         rotation_queues: list[Queue] | None
         for rotation in all_rotations:
-            conditions = [Queue.rotation_id == rotation.id, Queue.is_locked == False]
+            conditions = [
+                Queue.rotation_id == rotation.id,
+                Queue.is_locked == False,
+                Queue.is_captain_pick == is_captain_channel,
+            ]
             if queue_indices:
                 conditions.append(Queue.ordinal.in_(queue_indices))
             if queue_names:


### PR DESCRIPTION
## Summary

User-facing queue listings and lookups now filter by \`Queue.is_captain_pick\` matching the invocation channel. Each channel only shows and accepts adds for queues that belong to it.

- New helper \`checks.queue_is_captain_pick_for_channel(channel_id)\` derives the right filter from the captain channel cache.
- \`!add\` (no args) auto-adds only to queues matching the channel context.
- \`!add <name|ordinal>\` only resolves queues belonging to the channel, preventing cross-channel adds (e.g. \`!add foo\` from the main channel won't find a captain queue named foo).
- \`!status\` only lists queues belonging to the invocation channel.
- \`/list queue\` only shows queues belonging to the invocation channel.

Single-queue admin lookups by name (\`/queue show\` etc.) are unchanged — they're informational and reachable from either channel intentionally.

## Test plan

- [ ] From main channel, \`/list queue\` only shows non-captain queues
- [ ] From captain channel, \`/list queue\` only shows captain queues
- [ ] From main channel, \`!add\` (no args) adds only to non-captain queues
- [ ] From captain channel, \`!add\` (no args) adds only to captain queues
- [ ] \`!add <captain queue name>\` from main channel returns "No valid queues found"
- [ ] \`!status\` from each channel only shows that channel's queues

## Follow-ups

Next stacked PRs: \`start_draft()\`, the draft views, and \`finalize_draft()\` to actually run captain games.