### PR TITLE
Captain pick mode: draft flow

### DIFF
--- a/discord_bots/captain_pick.py
+++ b/discord_bots/captain_pick.py
@@ -1,0 +1,584 @@
+"""
+Captain pick draft flow. Imported by commands.create_game when the popped
+queue has is_captain_pick=True. Manages the lifecycle of a drafting
+InProgressGame: captain selection, board rendering, and finalization.
+
+The state machine itself (button/select interaction handling and message
+edits during the draft) lives in cogs.draft. Helpers here are stateless.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from random import uniform
+from typing import TYPE_CHECKING
+
+import discord
+import sqlalchemy
+from discord import CategoryChannel, Colour, Embed, Guild, TextChannel
+from discord.ext.commands import Bot
+from sqlalchemy.orm.session import Session as SQLAlchemySession
+from trueskill import Rating
+
+import discord_bots.config as config
+from discord_bots.bot import bot
+from discord_bots.cogs.in_progress_game import (
+    InProgressGameCommands,
+    InProgressGameView,
+)
+from discord_bots.models import (
+    Config,
+    DraftPick,
+    InProgressGame,
+    InProgressGameChannel,
+    InProgressGamePlayer,
+    Map,
+    Player,
+    PlayerCategoryTrueskill,
+    Queue,
+    QueuePlayer,
+    Rotation,
+    RotationMap,
+    Session,
+)
+from discord_bots.names import generate_be_name, generate_ds_name
+from discord_bots.utils import (
+    create_in_progress_game_embed,
+    execute_map_rotation,
+    get_category_trueskill,
+    get_team_voice_channels,
+    mean,
+    move_game_players,
+    send_in_guild_message,
+    send_message,
+    short_uuid,
+    win_probability_matchmaking,
+)
+
+if TYPE_CHECKING:
+    from discord_bots.cogs.draft import DraftCommands
+
+_log = logging.getLogger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Snake-draft turn calculator
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def picker_for_pick(pick_number: int, first_picker_team: int) -> int:
+    """
+    Snake-draft team for the given 1-indexed pick_number.
+
+    Pattern when first_picker_team=0:
+        pick 1 -> 0
+        picks 2,3 -> 1
+        picks 4,5 -> 0
+        picks 6,7 -> 1
+        ...
+    """
+    if pick_number == 1:
+        return first_picker_team
+    pair_index = (pick_number - 2) // 2
+    return (1 - first_picker_team) if pair_index % 2 == 0 else first_picker_team
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Player rating helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _player_rating(
+    session: SQLAlchemySession,
+    db_config: Config,
+    player: Player,
+    queue: Queue,
+    map_id: str,
+) -> tuple[float, float]:
+    """Return (mu, sigma) for a player, respecting category/map trueskill."""
+    if queue.category_id:
+        pct = get_category_trueskill(
+            session,
+            db_config,
+            player.id,
+            queue.map_trueskill_enabled,
+            queue.category_id,
+            map_id,
+            None,
+        )
+        return pct.mu, pct.sigma
+    return player.rated_trueskill_mu, player.rated_trueskill_sigma
+
+
+def _player_rank(
+    session: SQLAlchemySession,
+    db_config: Config,
+    player: Player,
+    queue: Queue,
+    map_id: str,
+) -> float:
+    mu, sigma = _player_rating(session, db_config, player, queue, map_id)
+    return mu - 3 * sigma
+
+
+def select_captains(
+    session: SQLAlchemySession,
+    players: list[Player],
+    queue: Queue,
+    map_id: str,
+) -> tuple[Player, Player]:
+    """
+    Pick the two highest-rated players as captains.
+
+    Tiebreaker: rank (mu - 3*sigma) desc, then mu desc, then player_id asc.
+    Returns (captain_a, captain_b) where captain_a is the higher-rated and
+    captain_b is the lower-rated.
+    """
+    db_config: Config = session.query(Config).first()
+    sorted_players = sorted(
+        players,
+        key=lambda p: (
+            -_player_rank(session, db_config, p, queue, map_id),
+            -_player_rating(session, db_config, p, queue, map_id)[0],
+            p.id,
+        ),
+    )
+    return sorted_players[0], sorted_players[1]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Draft state queries
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def get_first_picker_team(session: SQLAlchemySession, game_id: str) -> int | None:
+    """
+    Derive the team that picks first from the first DraftPick row.
+
+    Returns None if no picks have been made yet (i.e. the first-pick choice
+    hasn't been recorded). When 0 picks exist after a bot restart, the
+    cog re-prompts captain B for the choice.
+    """
+    first_pick = (
+        session.query(DraftPick)
+        .filter(DraftPick.in_progress_game_id == game_id)
+        .order_by(DraftPick.pick_number.asc())
+        .first()
+    )
+    if not first_pick:
+        return None
+    igp = (
+        session.query(InProgressGamePlayer)
+        .filter(
+            InProgressGamePlayer.in_progress_game_id == game_id,
+            InProgressGamePlayer.player_id == first_pick.captain_player_id,
+        )
+        .first()
+    )
+    return igp.team if igp else None
+
+
+def get_current_picker(
+    session: SQLAlchemySession, game_id: str, first_picker_team: int
+) -> InProgressGamePlayer | None:
+    """Return the InProgressGamePlayer (captain) whose turn is next, or None
+    if the draft is complete."""
+    pick_count = (
+        session.query(DraftPick)
+        .filter(DraftPick.in_progress_game_id == game_id)
+        .count()
+    )
+    total_players = (
+        session.query(InProgressGamePlayer)
+        .filter(InProgressGamePlayer.in_progress_game_id == game_id)
+        .count()
+    )
+    total_picks = total_players - 2  # subtract the two captains
+    next_pick_number = pick_count + 1
+    if next_pick_number > total_picks:
+        return None
+    next_team = picker_for_pick(next_pick_number, first_picker_team)
+    return (
+        session.query(InProgressGamePlayer)
+        .filter(
+            InProgressGamePlayer.in_progress_game_id == game_id,
+            InProgressGamePlayer.is_captain == True,
+            InProgressGamePlayer.team == next_team,
+        )
+        .first()
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Embed rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _format_player_line(player: Player, is_captain: bool) -> str:
+    prefix = "👑 " if is_captain else "• "
+    return f"{prefix}<@{player.id}>"
+
+
+def create_draft_embed(
+    session: SQLAlchemySession,
+    game: InProgressGame,
+) -> Embed:
+    """Render the draft state as an embed."""
+    igps = (
+        session.query(InProgressGamePlayer)
+        .filter(InProgressGamePlayer.in_progress_game_id == game.id)
+        .all()
+    )
+    player_ids = [igp.player_id for igp in igps]
+    players_by_id = {
+        p.id: p for p in session.query(Player).filter(Player.id.in_(player_ids)).all()
+    }
+
+    team0_lines: list[str] = []
+    team1_lines: list[str] = []
+    pool_lines: list[str] = []
+    for igp in igps:
+        player = players_by_id[igp.player_id]
+        if igp.team == 0:
+            team0_lines.append(_format_player_line(player, igp.is_captain))
+        elif igp.team == 1:
+            team1_lines.append(_format_player_line(player, igp.is_captain))
+        else:
+            pool_lines.append(_format_player_line(player, False))
+
+    first_picker_team = get_first_picker_team(session, game.id)
+    pick_count = (
+        session.query(DraftPick)
+        .filter(DraftPick.in_progress_game_id == game.id)
+        .count()
+    )
+    total_picks = len(igps) - 2
+
+    if first_picker_team is None and pool_lines:
+        captain_b = next(
+            (igp for igp in igps if igp.is_captain and igp.team == 1), None
+        )
+        state_desc = (
+            f"Awaiting <@{captain_b.player_id}>'s first/second pick choice."
+            if captain_b
+            else "Awaiting first/second pick choice."
+        )
+    elif pool_lines:
+        next_picker = get_current_picker(session, game.id, first_picker_team)
+        if next_picker:
+            state_desc = (
+                f"<@{next_picker.player_id}>'s turn "
+                f"(pick {pick_count + 1}/{total_picks})"
+            )
+        else:
+            state_desc = "Draft complete."
+    else:
+        state_desc = "Draft complete."
+
+    embed = Embed(
+        title=f"📋 Captain pick draft — {game.map_full_name}",
+        colour=Colour.blurple(),
+    )
+    embed.add_field(
+        name=f"🔴 {game.team0_name}",
+        value="\n".join(team0_lines) if team0_lines else "_(empty)_",
+        inline=True,
+    )
+    embed.add_field(
+        name=f"🔵 {game.team1_name}",
+        value="\n".join(team1_lines) if team1_lines else "_(empty)_",
+        inline=True,
+    )
+    embed.add_field(
+        name="Remaining",
+        value="\n".join(pool_lines) if pool_lines else "_(none)_",
+        inline=False,
+    )
+    embed.add_field(name="Status", value=state_desc, inline=False)
+    return embed
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Draft start
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def start_draft(
+    session: SQLAlchemySession,
+    queue: Queue,
+    next_map: Map,
+    rolled_random_map: bool,
+    player_ids: list[int],
+    lobby_channel: TextChannel,
+    guild: Guild,
+) -> None:
+    """
+    Begin a captain-pick draft.
+
+    Creates an InProgressGame with is_drafting=True, writes captain rows
+    (is_captain=True, team 0/1) and pool rows (team=NULL), creates the
+    match text channel, advances the map rotation (matching the existing
+    create_game behavior), and posts the FirstPickChoiceView.
+    """
+    # Lazy import to avoid circular: views/draft -> cogs/draft -> captain_pick
+    from discord_bots.views.draft import FirstPickChoiceView
+
+    db_config: Config = session.query(Config).first()
+    players: list[Player] = (
+        session.query(Player).filter(Player.id.in_(player_ids)).all()
+    )
+
+    captain_a, captain_b = select_captains(session, players, queue, next_map.id)
+    non_captains = [p for p in players if p.id not in (captain_a.id, captain_b.id)]
+
+    # Use mu (or category mu) average for InProgressGame.average_trueskill so
+    # downstream code that reads it still works.
+    all_mus = [
+        _player_rating(session, db_config, p, queue, next_map.id)[0] for p in players
+    ]
+    average_trueskill = mean(all_mus)
+
+    game = InProgressGame(
+        average_trueskill=average_trueskill,
+        map_id=next_map.id,
+        map_full_name=next_map.full_name,
+        map_short_name=next_map.short_name,
+        queue_id=queue.id,
+        team0_name=generate_be_name(),
+        team1_name=generate_ds_name(),
+        win_probability=0.0,  # populated in finalize_draft
+        is_drafting=True,
+    )
+    session.add(game)
+
+    # Captains: team 0 = higher-rated (captain A), team 1 = lower-rated (captain B)
+    session.add(
+        InProgressGamePlayer(
+            in_progress_game_id=game.id,
+            player_id=captain_a.id,
+            team=0,
+            is_captain=True,
+        )
+    )
+    session.add(
+        InProgressGamePlayer(
+            in_progress_game_id=game.id,
+            player_id=captain_b.id,
+            team=1,
+            is_captain=True,
+        )
+    )
+    for player in non_captains:
+        session.add(
+            InProgressGamePlayer(
+                in_progress_game_id=game.id,
+                player_id=player.id,
+                team=None,
+                is_captain=False,
+            )
+        )
+
+    # Create the match text channel under the tribes voice category.
+    short_game_id = short_uuid(game.id)
+    match_channel: TextChannel | None = None
+    category_channel: discord.abc.GuildChannel | None = guild.get_channel(
+        config.TRIBES_VOICE_CATEGORY_CHANNEL_ID
+    )
+    if isinstance(category_channel, CategoryChannel):
+        match_channel = await guild.create_text_channel(
+            f"{queue.name}-({short_game_id})", category=category_channel
+        )
+        session.add(
+            InProgressGameChannel(
+                in_progress_game_id=game.id, channel_id=match_channel.id
+            )
+        )
+        game.channel_id = match_channel.id
+    else:
+        _log.warning(
+            f"could not find tribes_voice_category with id "
+            f"{config.TRIBES_VOICE_CATEGORY_CHANNEL_ID} in guild"
+        )
+
+    # Post the first-pick-choice view in the match channel.
+    if match_channel:
+        draft_cog = bot.get_cog("DraftCommands")
+        embed = create_draft_embed(session, game)
+        embed.description = (
+            f"<@{captain_a.id}> and <@{captain_b.id}> are captains. "
+            f"<@{captain_b.id}>, do you want to pick first or second?"
+        )
+        view = FirstPickChoiceView(game.id, captain_b.id, draft_cog)
+        message = await match_channel.send(embed=embed, view=view)
+        game.message_id = message.id
+
+    # Remove queue players (game has started) — same as create_game.
+    session.query(QueuePlayer).filter(QueuePlayer.player_id.in_(player_ids)).delete()
+    session.commit()
+
+    # Advance rotation if not rolled random. Matches create_game behavior so
+    # captain games and traditional games share the same rotation cadence.
+    if not rolled_random_map:
+        await execute_map_rotation(queue.rotation_id, False)
+
+    # Notify the lobby channel that a draft has started.
+    summary = Embed(
+        title=f"📋 Captain pick draft '{queue.name}' ({short_game_id}) has begun",
+        description=(
+            f"Captains: <@{captain_a.id}> (🔴 {game.team0_name}), "
+            f"<@{captain_b.id}> (🔵 {game.team1_name}).\n"
+            f"Map: {next_map.full_name}.\n"
+            f"Drafting in <#{match_channel.id}>."
+            if match_channel
+            else f"Captains: <@{captain_a.id}>, <@{captain_b.id}>"
+        ),
+        colour=Colour.blurple(),
+    )
+    await lobby_channel.send(embed=summary)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Draft finalization
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def finalize_draft(game_id: str) -> None:
+    """
+    Called when the last pick lands. Computes win_probability, creates voice
+    channels, posts the standard InProgressGameView (Win/Loss/Tie/Cancel),
+    and flips is_drafting=False so the rest of the bot treats it as a
+    normal in-progress game.
+    """
+    session: SQLAlchemySession
+    with Session() as session:
+        game: InProgressGame | None = (
+            session.query(InProgressGame).filter(InProgressGame.id == game_id).first()
+        )
+        if not game or not game.is_drafting:
+            _log.warning(f"[finalize_draft] game {game_id} not found or not drafting")
+            return
+
+        guild = bot.get_guild(_guild_id_for_game(game))
+        if not guild:
+            _log.warning(f"[finalize_draft] guild not found for game {game_id}")
+            return
+
+        igps: list[InProgressGamePlayer] = (
+            session.query(InProgressGamePlayer)
+            .filter(InProgressGamePlayer.in_progress_game_id == game.id)
+            .all()
+        )
+        team0_player_ids = [igp.player_id for igp in igps if igp.team == 0]
+        team1_player_ids = [igp.player_id for igp in igps if igp.team == 1]
+
+        db_config: Config = session.query(Config).first()
+        queue: Queue | None = (
+            session.query(Queue).filter(Queue.id == game.queue_id).first()
+        )
+
+        team0_ratings: list[Rating] = []
+        team1_ratings: list[Rating] = []
+        for igp in igps:
+            player = session.query(Player).filter(Player.id == igp.player_id).first()
+            if not player or queue is None:
+                continue
+            mu, sigma = _player_rating(session, db_config, player, queue, game.map_id)
+            rating = Rating(mu=mu, sigma=sigma)
+            if igp.team == 0:
+                team0_ratings.append(rating)
+            else:
+                team1_ratings.append(rating)
+
+        if team0_ratings and team1_ratings:
+            game.win_probability = win_probability_matchmaking(
+                team0_ratings, team1_ratings
+            )
+
+        # Create voice channels under the tribes voice category.
+        category_channel: discord.abc.GuildChannel | None = guild.get_channel(
+            config.TRIBES_VOICE_CATEGORY_CHANNEL_ID
+        )
+        be_voice_channel = None
+        ds_voice_channel = None
+        if isinstance(category_channel, CategoryChannel):
+            be_voice_channel = await guild.create_voice_channel(
+                f"🔴 {game.team0_name}", category=category_channel
+            )
+            ds_voice_channel = await guild.create_voice_channel(
+                f"🔵 {game.team1_name}", category=category_channel
+            )
+            session.add(
+                InProgressGameChannel(
+                    in_progress_game_id=game.id, channel_id=be_voice_channel.id
+                )
+            )
+            session.add(
+                InProgressGameChannel(
+                    in_progress_game_id=game.id, channel_id=ds_voice_channel.id
+                )
+            )
+
+        game.is_drafting = False
+        session.commit()
+
+        # Post the standard in-progress game embed and view in the match channel.
+        match_channel = guild.get_channel(game.channel_id) if game.channel_id else None
+        in_progress_game_cog = bot.get_cog("InProgressGameCommands")
+        if (
+            match_channel
+            and in_progress_game_cog is not None
+            and isinstance(in_progress_game_cog, InProgressGameCommands)
+        ):
+            embed = await create_in_progress_game_embed(session, game, guild)
+            embed.title = (
+                f"🚩 Game '{queue.name if queue else ''}' "
+                f"({short_uuid(game.id)}) has begun!"
+            )
+            view = InProgressGameView(game.id, in_progress_game_cog)
+            message = await match_channel.send(embed=embed, view=view)
+            # Replace the draft message_id with the post-finalize message.
+            game.message_id = message.id
+            session.commit()
+
+            # DM each player a copy of the embed with their voice channel link.
+            send_message_coroutines = []
+            for igp in igps:
+                voice = be_voice_channel if igp.team == 0 else ds_voice_channel
+                if voice:
+                    send_message_coroutines.append(
+                        send_in_guild_message(
+                            guild,
+                            igp.player_id,
+                            message_content=voice.jump_url,
+                            embed=embed,
+                        )
+                    )
+            if send_message_coroutines:
+                await asyncio.gather(*send_message_coroutines, return_exceptions=True)
+
+        # Optionally move players to voice channels.
+        if (
+            config.ENABLE_VOICE_MOVE
+            and queue
+            and queue.move_enabled
+            and be_voice_channel
+            and ds_voice_channel
+        ):
+            await move_game_players(short_uuid(game.id), None, guild)
+
+
+def _guild_id_for_game(game: InProgressGame) -> int:
+    """
+    Derive the guild_id from the bot's guilds. We don't store guild_id on
+    InProgressGame, but the bot is typically in a single guild and the
+    match channel belongs to it.
+    """
+    if game.channel_id:
+        channel = bot.get_channel(game.channel_id)
+        if channel and channel.guild:
+            return channel.guild.id
+    # Fallback: first guild the bot is in.
+    if bot.guilds:
+        return bot.guilds[0].id
+    return 0

--- a/discord_bots/cogs/draft.py
+++ b/discord_bots/cogs/draft.py
@@ -1,0 +1,411 @@
+"""
+DraftCommands cog. State machine for captain pick drafts:
+
+- handle_first_pick_choice: captain B clicks Pick first/second; transition
+  to DraftPickView for the chosen first picker.
+- handle_pick: a captain selects a player from the dropdown; persist to
+  DraftPick + InProgressGamePlayer.team, advance the view (or finalize).
+- handle_pick_timeout: 2-minute pick timer expires; auto-pick a random
+  remaining player.
+
+cog_load re-attaches views for every drafting game on bot restart.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+
+from discord import Colour, Embed, Interaction, Message, TextChannel
+from discord.ext import commands
+from discord.ext.commands import Bot
+from sqlalchemy.orm.session import Session as SQLAlchemySession
+
+from discord_bots.bot import bot
+from discord_bots.captain_pick import (
+    create_draft_embed,
+    finalize_draft,
+    get_current_picker,
+    get_first_picker_team,
+    picker_for_pick,
+)
+from discord_bots.models import (
+    DraftPick,
+    InProgressGame,
+    InProgressGamePlayer,
+    Player,
+    Session,
+)
+from discord_bots.views.draft import DraftPickView, FirstPickChoiceView
+
+_log = logging.getLogger(__name__)
+
+
+class DraftCommands(commands.Cog):
+    def __init__(self, bot: Bot):
+        self.bot: Bot = bot
+
+    async def cog_load(self) -> None:
+        """
+        Re-attach views for any in-progress drafts after a bot restart.
+
+        - 0 picks made → re-post FirstPickChoiceView (captain B re-decides).
+        - 1+ picks made → re-post DraftPickView for the current picker
+          (snake formula). Pick timer resets to 2 minutes; per design
+          this is acceptable.
+        """
+        session: SQLAlchemySession
+        with Session() as session:
+            drafting_games: list[InProgressGame] = (
+                session.query(InProgressGame)
+                .filter(InProgressGame.is_drafting == True)
+                .all()
+            )
+            for game in drafting_games:
+                if not game.message_id or not game.channel_id:
+                    continue
+                channel = self.bot.get_channel(game.channel_id)
+                if not isinstance(channel, TextChannel):
+                    continue
+                try:
+                    message = await channel.fetch_message(game.message_id)
+                except Exception as e:
+                    _log.warning(
+                        f"[DraftCommands.cog_load] could not fetch "
+                        f"message {game.message_id}: {e}"
+                    )
+                    continue
+
+                first_picker_team = get_first_picker_team(session, game.id)
+                if first_picker_team is None:
+                    # No picks yet — re-prompt for first/second pick choice.
+                    captain_b = (
+                        session.query(InProgressGamePlayer)
+                        .filter(
+                            InProgressGamePlayer.in_progress_game_id == game.id,
+                            InProgressGamePlayer.is_captain == True,
+                            InProgressGamePlayer.team == 1,
+                        )
+                        .first()
+                    )
+                    if not captain_b:
+                        continue
+                    view = FirstPickChoiceView(game.id, captain_b.player_id, self)
+                    self.bot.add_view(view, message_id=message.id)
+                else:
+                    # Picks in progress — repost a fresh DraftPickView.
+                    await self._post_pick_view(session, game, message)
+
+    async def _post_pick_view(
+        self,
+        session: SQLAlchemySession,
+        game: InProgressGame,
+        message: Message,
+        first_picker_team_override: int | None = None,
+    ) -> None:
+        """Edit `message` to show a fresh DraftPickView for the current picker.
+
+        first_picker_team_override is needed when this is called immediately
+        after the FirstPickChoiceView click — at that moment no DraftPick rows
+        exist yet, so the choice has to be passed in explicitly.
+        """
+        first_picker_team = first_picker_team_override
+        if first_picker_team is None:
+            first_picker_team = get_first_picker_team(session, game.id)
+        if first_picker_team is None:
+            return
+        current_picker = get_current_picker(session, game.id, first_picker_team)
+        if current_picker is None:
+            # Draft is complete — finalize.
+            await finalize_draft(game.id)
+            return
+
+        pool = (
+            session.query(InProgressGamePlayer)
+            .filter(
+                InProgressGamePlayer.in_progress_game_id == game.id,
+                InProgressGamePlayer.team == None,
+            )
+            .all()
+        )
+        pool_player_ids = [igp.player_id for igp in pool]
+        pool_players = {
+            p.id: p
+            for p in session.query(Player).filter(Player.id.in_(pool_player_ids)).all()
+        }
+        remaining = [
+            (igp.player_id, pool_players[igp.player_id].name)
+            for igp in pool
+            if igp.player_id in pool_players
+        ]
+
+        pick_count = (
+            session.query(DraftPick)
+            .filter(DraftPick.in_progress_game_id == game.id)
+            .count()
+        )
+        view = DraftPickView(
+            game_id=game.id,
+            current_picker_id=current_picker.player_id,
+            pick_number=pick_count + 1,
+            remaining_players=remaining,
+            cog=self,
+        )
+        embed = create_draft_embed(session, game)
+        await message.edit(embed=embed, view=view)
+
+    async def handle_first_pick_choice(
+        self,
+        interaction: Interaction,
+        game_id: str,
+        captain_b_picks_first: bool,
+    ) -> None:
+        """Captain B chose first/second. Transition to the pick view."""
+        await interaction.response.defer()
+        session: SQLAlchemySession
+        with Session() as session:
+            game = (
+                session.query(InProgressGame)
+                .filter(InProgressGame.id == game_id)
+                .first()
+            )
+            if not game or not game.is_drafting:
+                return
+            # Captain B is team 1, captain A is team 0.
+            # Captain B picks first => first_picker_team = 1
+            # Captain B picks second => first_picker_team = 0 (i.e. captain A)
+            first_picker_team = 1 if captain_b_picks_first else 0
+            captain_a_or_b = (
+                session.query(InProgressGamePlayer)
+                .filter(
+                    InProgressGamePlayer.in_progress_game_id == game.id,
+                    InProgressGamePlayer.is_captain == True,
+                    InProgressGamePlayer.team == first_picker_team,
+                )
+                .first()
+            )
+            if not captain_a_or_b or not interaction.message:
+                return
+
+            # The choice will be encoded into the first DraftPick row when
+            # the captain selects a player. Until then, pass first_picker_team
+            # explicitly so _post_pick_view can render the right captain's view.
+            await self._post_pick_view(
+                session,
+                game,
+                interaction.message,
+                first_picker_team_override=first_picker_team,
+            )
+
+    async def handle_pick(
+        self,
+        interaction: Interaction,
+        game_id: str,
+        picked_player_id: int,
+        expected_pick_number: int,
+    ) -> None:
+        """A captain selected a player. Persist + advance the view."""
+        await interaction.response.defer()
+        session: SQLAlchemySession
+        with Session() as session:
+            game = (
+                session.query(InProgressGame)
+                .filter(InProgressGame.id == game_id)
+                .first()
+            )
+            if not game or not game.is_drafting:
+                return
+
+            pick_count = (
+                session.query(DraftPick)
+                .filter(DraftPick.in_progress_game_id == game.id)
+                .count()
+            )
+            if pick_count + 1 != expected_pick_number:
+                # Stale view; refresh and bail.
+                if interaction.message:
+                    await self._post_pick_view(session, game, interaction.message)
+                return
+
+            # Determine first_picker_team: if this is pick 1, the picker is the
+            # team whose captain matches interaction.user.id; otherwise it's
+            # already encoded in the first DraftPick row.
+            first_picker_team = get_first_picker_team(session, game.id)
+            if first_picker_team is None:
+                first_picker_igp = (
+                    session.query(InProgressGamePlayer)
+                    .filter(
+                        InProgressGamePlayer.in_progress_game_id == game.id,
+                        InProgressGamePlayer.player_id == interaction.user.id,
+                        InProgressGamePlayer.is_captain == True,
+                    )
+                    .first()
+                )
+                if not first_picker_igp:
+                    return
+                first_picker_team = first_picker_igp.team
+
+            # Verify it's actually this captain's turn (snake formula).
+            expected_team = picker_for_pick(expected_pick_number, first_picker_team)
+            picker_igp = (
+                session.query(InProgressGamePlayer)
+                .filter(
+                    InProgressGamePlayer.in_progress_game_id == game.id,
+                    InProgressGamePlayer.is_captain == True,
+                    InProgressGamePlayer.team == expected_team,
+                )
+                .first()
+            )
+            if not picker_igp or picker_igp.player_id != interaction.user.id:
+                return
+
+            await self._record_pick(
+                session,
+                game,
+                captain_player_id=interaction.user.id,
+                picked_player_id=picked_player_id,
+                pick_number=expected_pick_number,
+                pick_team=expected_team,
+            )
+
+            # Advance: either finalize, or post the next pick view.
+            session.commit()
+            if interaction.message:
+                # Refresh from DB after commit.
+                game = (
+                    session.query(InProgressGame)
+                    .filter(InProgressGame.id == game_id)
+                    .first()
+                )
+                if game:
+                    await self._advance_or_finalize(session, game, interaction.message)
+
+    async def handle_pick_timeout(
+        self, game_id: str, expected_pick_number: int
+    ) -> None:
+        """2-minute timer expired: auto-pick a random remaining player."""
+        session: SQLAlchemySession
+        with Session() as session:
+            game = (
+                session.query(InProgressGame)
+                .filter(InProgressGame.id == game_id)
+                .first()
+            )
+            if not game or not game.is_drafting:
+                return
+
+            pick_count = (
+                session.query(DraftPick)
+                .filter(DraftPick.in_progress_game_id == game.id)
+                .count()
+            )
+            if pick_count + 1 != expected_pick_number:
+                # Pick already happened (race condition); nothing to do.
+                return
+
+            first_picker_team = get_first_picker_team(session, game.id)
+            if first_picker_team is None:
+                # Shouldn't happen — pick view shouldn't be active without
+                # a first-pick choice.
+                return
+
+            current_picker = get_current_picker(session, game.id, first_picker_team)
+            if current_picker is None:
+                return
+
+            pool = (
+                session.query(InProgressGamePlayer)
+                .filter(
+                    InProgressGamePlayer.in_progress_game_id == game.id,
+                    InProgressGamePlayer.team == None,
+                )
+                .all()
+            )
+            if not pool:
+                return
+            chosen = random.choice(pool)
+
+            await self._record_pick(
+                session,
+                game,
+                captain_player_id=current_picker.player_id,
+                picked_player_id=chosen.player_id,
+                pick_number=expected_pick_number,
+                pick_team=current_picker.team,
+            )
+            session.commit()
+
+            game = (
+                session.query(InProgressGame)
+                .filter(InProgressGame.id == game_id)
+                .first()
+            )
+            if not game or not game.channel_id or not game.message_id:
+                return
+            channel = self.bot.get_channel(game.channel_id)
+            if not isinstance(channel, TextChannel):
+                return
+            try:
+                message = await channel.fetch_message(game.message_id)
+            except Exception:
+                return
+            await channel.send(
+                embed=Embed(
+                    description=(
+                        f"⏰ <@{current_picker.player_id}>'s pick timer "
+                        f"expired — auto-picked <@{chosen.player_id}>."
+                    ),
+                    colour=Colour.yellow(),
+                )
+            )
+            await self._advance_or_finalize(session, game, message)
+
+    async def _record_pick(
+        self,
+        session: SQLAlchemySession,
+        game: InProgressGame,
+        captain_player_id: int,
+        picked_player_id: int,
+        pick_number: int,
+        pick_team: int,
+    ) -> None:
+        """Persist a DraftPick row and assign the picked player to the team."""
+        session.add(
+            DraftPick(
+                in_progress_game_id=game.id,
+                pick_number=pick_number,
+                captain_player_id=captain_player_id,
+                picked_player_id=picked_player_id,
+            )
+        )
+        picked_igp = (
+            session.query(InProgressGamePlayer)
+            .filter(
+                InProgressGamePlayer.in_progress_game_id == game.id,
+                InProgressGamePlayer.player_id == picked_player_id,
+            )
+            .first()
+        )
+        if picked_igp:
+            picked_igp.team = pick_team
+
+    async def _advance_or_finalize(
+        self,
+        session: SQLAlchemySession,
+        game: InProgressGame,
+        message: Message,
+    ) -> None:
+        """If draft is complete, finalize. Otherwise post the next pick view."""
+        remaining = (
+            session.query(InProgressGamePlayer)
+            .filter(
+                InProgressGamePlayer.in_progress_game_id == game.id,
+                InProgressGamePlayer.team == None,
+            )
+            .count()
+        )
+        if remaining == 0:
+            await message.edit(embed=create_draft_embed(session, game), view=None)
+            await finalize_draft(game.id)
+        else:
+            await self._post_pick_view(session, game, message)

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -306,6 +306,22 @@ async def create_game(
                 session.query(Map).filter(Map.id == next_rotation_map.map_id).first()
             )
 
+        if queue.is_captain_pick:
+            # Lazy import to avoid circular: captain_pick imports from
+            # cogs.in_progress_game which can drag in commands during init.
+            from discord_bots.captain_pick import start_draft as _start_draft
+
+            await _start_draft(
+                session,
+                queue,
+                next_map,
+                rolled_random_map,
+                player_ids,
+                channel,
+                guild,
+            )
+            return
+
         if len(player_ids) == 1:
             # Useful for debugging, no real world application
             players = session.query(Player).filter(Player.id == player_ids[0]).all()

--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -21,6 +21,7 @@ from discord_bots.cogs.admin import AdminCommands
 from discord_bots.cogs.category import CategoryCommands
 from discord_bots.cogs.common import CommonCommands
 from discord_bots.cogs.config import ConfigCommands
+from discord_bots.cogs.draft import DraftCommands
 from discord_bots.cogs.economy import EconomyCommands
 from discord_bots.cogs.in_progress_game import InProgressGameCommands
 from discord_bots.cogs.list import ListCommands
@@ -328,6 +329,7 @@ async def setup():
     await bot.add_cog(VoteCommands(bot))
     await bot.add_cog(NotificationCommands(bot))
     await bot.add_cog(ConfigCommands(bot))
+    await bot.add_cog(DraftCommands(bot))
     add_player_task.start()
     afk_timer_task.start()
     leaderboard_task.start()

--- a/discord_bots/views/draft.py
+++ b/discord_bots/views/draft.py
@@ -1,0 +1,143 @@
+"""
+Discord UI views for the captain pick draft flow.
+
+Two views:
+- FirstPickChoiceView — captain B's "Pick first / Pick second" buttons.
+  Persistent (timeout=None) so it survives bot restarts via add_view.
+- DraftPickView — Select dropdown of remaining players, gated to the current
+  picker. Non-persistent with a 2-minute timeout; on timeout, the cog auto-
+  picks a random remaining player. On bot restart the cog re-posts a fresh
+  view with a new timer (acceptable per design).
+
+Both views delegate state mutations to DraftCommands.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from discord import ButtonStyle, Colour, Embed, Interaction, SelectOption
+from discord.ui import Button, Select, button
+
+from discord_bots.views.base import BaseView
+
+if TYPE_CHECKING:
+    from discord_bots.cogs.draft import DraftCommands
+
+_log = logging.getLogger(__name__)
+
+
+class FirstPickChoiceView(BaseView):
+    """Captain B chooses whether to pick first or second."""
+
+    def __init__(self, game_id: str, captain_b_id: int, cog: "DraftCommands | None"):
+        super().__init__(timeout=None)
+        self.game_id = game_id
+        self.captain_b_id = captain_b_id
+        self.cog = cog
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if interaction.user.id != self.captain_b_id:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="Only the lower-rated captain can choose pick order.",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    @button(
+        label="Pick first",
+        style=ButtonStyle.primary,
+        custom_id="captain_pick_first_pick_choice:first",
+        emoji="1️⃣",
+    )
+    async def first_button(self, interaction: Interaction, button: Button):
+        if self.cog is None:
+            self.cog = interaction.client.get_cog("DraftCommands")
+        if self.cog is None:
+            return
+        await self.cog.handle_first_pick_choice(
+            interaction, self.game_id, captain_b_picks_first=True
+        )
+        self.stop()
+
+    @button(
+        label="Pick second",
+        style=ButtonStyle.secondary,
+        custom_id="captain_pick_first_pick_choice:second",
+        emoji="2️⃣",
+    )
+    async def second_button(self, interaction: Interaction, button: Button):
+        if self.cog is None:
+            self.cog = interaction.client.get_cog("DraftCommands")
+        if self.cog is None:
+            return
+        await self.cog.handle_first_pick_choice(
+            interaction, self.game_id, captain_b_picks_first=False
+        )
+        self.stop()
+
+
+class DraftPickView(BaseView):
+    """Current picker selects a player from a dropdown of the remaining pool."""
+
+    # 2 minute timeout per pick. On timeout, the cog auto-picks a random
+    # remaining player. See cogs/draft.py:on_pick_timeout.
+    PICK_TIMEOUT_SECONDS = 120
+
+    def __init__(
+        self,
+        game_id: str,
+        current_picker_id: int,
+        pick_number: int,
+        remaining_players: list[tuple[int, str]],
+        cog: "DraftCommands",
+    ):
+        super().__init__(timeout=self.PICK_TIMEOUT_SECONDS)
+        self.game_id = game_id
+        self.current_picker_id = current_picker_id
+        self.pick_number = pick_number
+        self.cog = cog
+
+        options = [
+            SelectOption(label=name[:100], value=str(player_id))
+            for player_id, name in remaining_players[:25]
+        ]
+        select = Select(
+            placeholder=f"Pick {pick_number}: choose a player",
+            options=options,
+            min_values=1,
+            max_values=1,
+        )
+
+        async def select_callback(interaction: Interaction):
+            picked_player_id = int(select.values[0])
+            await self.cog.handle_pick(
+                interaction,
+                self.game_id,
+                picked_player_id=picked_player_id,
+                expected_pick_number=self.pick_number,
+            )
+            self.stop()
+
+        select.callback = select_callback
+        self.add_item(select)
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        if interaction.user.id != self.current_picker_id:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="It's not your turn to pick.",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def on_timeout(self) -> None:
+        await self.cog.handle_pick_timeout(self.game_id, self.pick_number)


### PR DESCRIPTION
## Summary

End-to-end captain pick draft: from queue pop, through captain selection and snake-picking, to a finalized in-progress game with the standard Win/Loss/Tie/Cancel flow.

This combines tasks 5–9 from the plan (\`docs/captain-pick-plan.md\`) since they're tightly coupled — each one alone leaves the bot in a stuck state.

## What lands

**New modules:**
- \`discord_bots/captain_pick.py\` — \`start_draft\`, \`finalize_draft\`, captain selection (mu − 3σ → mu → player_id tiebreaker), snake-draft turn calculator, draft state embed renderer.
- \`discord_bots/views/draft.py\` — \`FirstPickChoiceView\` (persistent: captain B's "Pick first / Pick second"), \`DraftPickView\` (Select dropdown, 2-min timeout with random auto-pick fallback).
- \`discord_bots/cogs/draft.py\` — \`DraftCommands\` cog. State machine for first-pick choice, picks, and pick timeouts. \`cog_load\` re-attaches the right view per drafting game on bot restart.

**Branching point:**
- \`commands.create_game\` now branches to \`start_draft\` when \`queue.is_captain_pick\`. The traditional auto-team flow is unchanged.

## State design notes

- **First-picker decision** is derived from the first \`DraftPick\` row's \`captain_player_id\`. No extra schema needed. After a bot restart with 0 picks (rare window between captain B clicking and the first selection), captain B re-prompts for pick order.
- **\`InProgressGamePlayer.team\`** is NULL for the unpicked pool; flips to 0 or 1 as picks land. Draft is "complete" when no NULL rows remain, at which point \`finalize_draft\` runs and \`is_drafting\` flips to False.
- **\`DraftPick\`** is the audit/history log; uniqueness enforced via \`(in_progress_game_id, pick_number)\`.

## What's deferred

The plan's tasks 10–16 (sub-during-draft restart, autosub disable, win-probability hide, economy/raffle skip, TrueSkill skip, stats filter) are follow-up PRs. Right now captain games still:
- Fire economy/prediction creation
- Award raffle tickets at finish
- Write TrueSkill ratings on finish
- Show win probability in embeds
- Appear in leaderboards/stats

These will be gated in subsequent stacked PRs.

## Test plan

- [ ] Set up a captain channel via \`/config setcaptainchannel\`
- [ ] Create a captain queue with size 4 in that channel
- [ ] 4 players \`!add\` from the captain channel
- [ ] Match channel is created with FirstPickChoiceView; lobby gets a summary
- [ ] Lower-rated captain clicks "Pick first" or "Pick second"
- [ ] DraftPickView appears; only the current picker can select
- [ ] After all picks land, voice channels are created and InProgressGameView posts
- [ ] Win/Loss/Tie buttons work as expected
- [ ] Restart the bot mid-draft → DraftPickView re-attaches with fresh 2-min timer
- [ ] Don't pick for 2 minutes → random auto-pick happens, draft continues