### PR TITLE
Captain pick mode: disable autosub, block sub-during-draft

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -901,6 +901,19 @@ async def autosub(ctx: Context, member: Member = None):
         .filter(InProgressGame.id == ipg_player.in_progress_game_id)
         .first()
     )
+    autosub_queue: Queue | None = (
+        session.query(Queue).filter(Queue.id == game.queue_id).first()
+    )
+    if autosub_queue and autosub_queue.is_captain_pick:
+        await send_message(
+            message.channel,
+            embed_description=(
+                "Autosub is not supported for captain pick games. Use `!sub` "
+                "to manually substitute (this will restart the draft)."
+            ),
+            colour=Colour.red(),
+        )
+        return
     results = (
         session.query(Player.id, Player.name)
         .join(InProgressGamePlayer)
@@ -1562,6 +1575,22 @@ async def sub(ctx: Context, member: Member):
         await send_message(
             channel=message.channel,
             embed_description=f"{escape_markdown(caller.name)} and {escape_markdown(callee.name)} are not in a game",
+            colour=Colour.red(),
+        )
+        return
+
+    # Sub-during-draft is not yet implemented (the proper behavior is to
+    # restart the draft from scratch with the new player set; that's a
+    # follow-up). For now, block /sub on drafting games to avoid leaving the
+    # draft in a half-broken state.
+    sub_target_game = caller_game or callee_game
+    if sub_target_game and sub_target_game.is_drafting:
+        await send_message(
+            channel=message.channel,
+            embed_description=(
+                "Substitutions during a captain pick draft aren't supported "
+                "yet. Wait for the draft to finish before subbing."
+            ),
             colour=Colour.red(),
         )
         return


### PR DESCRIPTION
## Summary

Two narrow guards on substitution flows for captain pick games:

- **\`!autosub\`** early-returns with a friendly message when the in-progress game's queue is captain-pick. Auto-substituting into a hand-picked roster doesn't make sense, and it would also crash on the \`team == 0\` filters during the draft phase (where unpicked players have NULL team).
- **\`!sub\`** early-returns with a "not yet supported" message when the target game is drafting (\`is_drafting=True\`). Per the plan, sub-during-draft is supposed to fully restart the draft (re-picking captains if applicable). That's a follow-up PR. Until then, block it cleanly rather than leaving the draft in a half-broken state.

## Note on the broader nullable-team read sweep

The audit-flagged read sites in \`utils.py\` (\`in_progress_game_str\`, \`create_in_progress_game_embed\`, etc.) all use SQL queries with \`team == 0\` / \`team == 1\`. Standard SQL semantics: \`NULL == 0\` is NULL/UNKNOWN, so unpicked players are silently excluded. Drafting games would render with empty rosters in those embeds — suboptimal but doesn't crash. No code changes there for this PR.

## Test plan

- [ ] \`!autosub\` on a captain game → "Autosub is not supported..." message
- [ ] \`!autosub\` on a traditional game → unchanged (works as before)
- [ ] \`!sub @user\` on a drafting captain game → "Substitutions... aren't supported yet" message
- [ ] \`!sub @user\` on a finalized captain game → works (the captain game is now treated like any in-progress game)
- [ ] \`!sub @user\` on a traditional game → unchanged

## Follow-ups

- Sub-during-draft restart logic (task 10) — replaces the temporary block with the proper restart flow.
- Hide \`win_probability\` rendering for captain games (task 13).