### PR TITLE
Captain pick mode: hide win_probability rendering

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1010,19 +1010,31 @@ async def autosub(ctx: Context, member: Member = None):
         team1_player_names_before,
         team1_player_names_after,
     )
+    sub_queue_for_embed: Queue | None = (
+        session.query(Queue).filter(Queue.id == game.queue_id).first()
+    )
+    sub_hide_winprob = (
+        sub_queue_for_embed is not None and sub_queue_for_embed.is_captain_pick
+    )
+    sub_team0_winprob = (
+        "" if sub_hide_winprob else f" ({round(100 * game.win_probability, 1)}%)"
+    )
+    sub_team1_winprob = (
+        "" if sub_hide_winprob else f" ({round(100 * (1 - game.win_probability), 1)}%)"
+    )
     for i, field in enumerate(embed.fields):
         # brute force iteration through the embed's fields until we find the original team0 and team1 embeds to update
         if field.name and game.team0_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"🔴 {game.team0_name} ({round(100 * game.win_probability, 1)}%)",
+                name=f"🔴 {game.team0_name}{sub_team0_winprob}",
                 value=team0_diff_vaules,
                 inline=True,
             )
         if field.name and game.team1_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"🔵 {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%)",
+                name=f"🔵 {game.team1_name}{sub_team1_winprob}",
                 value=team1_diff_values,
                 inline=True,
             )
@@ -1389,6 +1401,11 @@ async def _rebalance_game(
     assert message.guild
     assert message.channel
     queue: Queue = session.query(Queue).filter(Queue.id == game.queue_id).first()
+    if queue and queue.is_captain_pick:
+        # Captain pick games have hand-picked rosters; don't re-balance via
+        # TrueSkill on a sub. The replacement player slots into the same
+        # team as the player they're replacing (handled by /sub itself).
+        return
     db_config: Config = session.query(Config).first()
 
     game_players = (
@@ -1690,19 +1707,31 @@ async def sub(ctx: Context, member: Member):
         team1_player_names_before,
         team1_player_names_after,
     )
+    sub_queue_for_embed: Queue | None = (
+        session.query(Queue).filter(Queue.id == game.queue_id).first()
+    )
+    sub_hide_winprob = (
+        sub_queue_for_embed is not None and sub_queue_for_embed.is_captain_pick
+    )
+    sub_team0_winprob = (
+        "" if sub_hide_winprob else f" ({round(100 * game.win_probability, 1)}%)"
+    )
+    sub_team1_winprob = (
+        "" if sub_hide_winprob else f" ({round(100 * (1 - game.win_probability), 1)}%)"
+    )
     for i, field in enumerate(embed.fields):
         # brute force iteration through the embed's fields until we find the original team0 and team1 embeds to update
         if field.name and game.team0_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"🔴 {game.team0_name} ({round(100 * game.win_probability, 1)}%)",
+                name=f"🔴 {game.team0_name}{sub_team0_winprob}",
                 value=team0_diff_vaules,
                 inline=True,
             )
         if field.name and game.team1_name in field.name:
             embed.set_field_at(
                 i,
-                name=f"🔵 {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%)",
+                name=f"🔵 {game.team1_name}{sub_team1_winprob}",
                 value=team1_diff_values,
                 inline=True,
             )

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -503,10 +503,14 @@ def finished_game_str(finished_game: FinishedGame, debug: bool = False) -> str:
             team1_names = ", ".join(
                 sorted([escape_markdown(player.name) for player in team1_players])
             )
-        team0_win_prob = round(100 * finished_game.win_probability, 1)
-        team1_win_prob = round(100 - team0_win_prob, 1)
-        team0_str = f"{finished_game.team0_name} ({team0_win_prob}%): {team0_names}"
-        team1_str = f"{finished_game.team1_name} ({team1_win_prob}%): {team1_names}"
+        if finished_game.is_captain_pick:
+            team0_str = f"{finished_game.team0_name}: {team0_names}"
+            team1_str = f"{finished_game.team1_name}: {team1_names}"
+        else:
+            team0_win_prob = round(100 * finished_game.win_probability, 1)
+            team1_win_prob = round(100 - team0_win_prob, 1)
+            team0_str = f"{finished_game.team0_name} ({team0_win_prob}%): {team0_names}"
+            team1_str = f"{finished_game.team1_name} ({team1_win_prob}%): {team1_names}"
 
         if finished_game.winning_team == 0:
             output += f"\n**{team0_str}**"
@@ -711,8 +715,15 @@ async def create_in_progress_game_embed(
     team0_player_names.sort(key=str.casefold)
     team1_player_names.sort(key=str.casefold)
     newline = "\n"
+    hide_winprob = queue is not None and queue.is_captain_pick
+    team0_winprob_suffix = (
+        "" if hide_winprob else f" ({round(100 * game.win_probability, 1)}%)"
+    )
+    team1_winprob_suffix = (
+        "" if hide_winprob else f" ({round(100 * (1 - game.win_probability), 1)}%)"
+    )
     embed.add_field(
-        name=f"🔴 {game.team0_name} ({round(100 * game.win_probability, 1)}%)",
+        name=f"🔴 {game.team0_name}{team0_winprob_suffix}",
         value=(
             f"\n>>> {newline.join(team0_player_names)}"
             if team0_player_names
@@ -721,7 +732,7 @@ async def create_in_progress_game_embed(
         inline=True,
     )
     embed.add_field(
-        name=f"🔵 {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%)",
+        name=f"🔵 {game.team1_name}{team1_winprob_suffix}",
         value=(
             f"\n>>> {newline.join(team1_player_names)}"
             if team1_player_names
@@ -842,13 +853,18 @@ async def create_condensed_in_progress_game_embed(
     team1_player_names.sort(key=str.casefold)
     content = ""
     content += f"🗺️ Map: **{game.map_full_name} ({game.map_short_name})**"
-    content += f"\n🔴 {game.team0_name} ({round(100 * game.win_probability, 1)}%):"
+    hide_winprob = queue is not None and queue.is_captain_pick
+    team0_winprob_suffix = (
+        "" if hide_winprob else f" ({round(100 * game.win_probability, 1)}%)"
+    )
+    team1_winprob_suffix = (
+        "" if hide_winprob else f" ({round(100 * (1 - game.win_probability), 1)}%)"
+    )
+    content += f"\n🔴 {game.team0_name}{team0_winprob_suffix}:"
     content += (
         f'\n> {", ".join(team0_player_names)}' if team0_player_names else "\n> ** **"
     )
-    content += (
-        f"\n🔵 {game.team1_name} ({round(100 * (1 - game.win_probability), 1)}%):"
-    )
+    content += f"\n🔵 {game.team1_name}{team1_winprob_suffix}:"
     content += (
         f'\n> {", ".join(team1_player_names)}' if team1_player_names else "\n> ** **"
     )
@@ -958,13 +974,23 @@ def create_finished_game_embed(
             team0_embed_value = f"\n>>> {newline.join(team0_player_names)}"
         if team1_player_names:
             team1_embed_value = f"\n>>> {newline.join(team1_player_names)}"
+    fg_team0_winprob_suffix = (
+        ""
+        if finished_game.is_captain_pick
+        else f" ({round(100 * finished_game.win_probability, 1)}%)"
+    )
+    fg_team1_winprob_suffix = (
+        ""
+        if finished_game.is_captain_pick
+        else f" ({round(100*(1 - finished_game.win_probability), 1)}%)"
+    )
     embed.add_field(
-        name=f"{be_str} ({round(100 * finished_game.win_probability, 1)}%)",
+        name=f"{be_str}{fg_team0_winprob_suffix}",
         value=team0_embed_value,
         inline=True,
     )
     embed.add_field(
-        name=f"{ds_str} ({round(100*(1 - finished_game.win_probability), 1)}%)",
+        name=f"{ds_str}{fg_team1_winprob_suffix}",
         value=team1_embed_value,
         inline=True,
     )
@@ -1037,13 +1063,24 @@ def create_cancelled_game_embed(
         )
         .all()
     )
+    cancel_hide_winprob = queue is not None and queue.is_captain_pick
+    cancel_team0_winprob_suffix = (
+        ""
+        if cancel_hide_winprob
+        else f" ({round(100 * in_progress_game.win_probability, 1)}%)"
+    )
+    cancel_team1_winprob_suffix = (
+        ""
+        if cancel_hide_winprob
+        else f" ({round(100*(1 - in_progress_game.win_probability), 1)}%)"
+    )
     embed.add_field(
-        name=f"{in_progress_game.team0_name} ({round(100 * in_progress_game.win_probability, 1)}%)",
+        name=f"{in_progress_game.team0_name}{cancel_team0_winprob_suffix}",
         value="\n".join([f"> {ipgp.player.name}" for ipgp in team0_fg_players]),
         inline=True,
     )
     embed.add_field(
-        name=f"{in_progress_game.team1_name} ({round(100*(1 - in_progress_game.win_probability), 1)}%)",
+        name=f"{in_progress_game.team1_name}{cancel_team1_winprob_suffix}",
         value="\n".join([f"> {ipgp.player.name}" for ipgp in team1_fg_players]),
         inline=True,
     )


### PR DESCRIPTION
## Summary

Captain pick games no longer expose the \`(X%)\` win-probability suffix in user-facing embeds and team strings. The \`InProgressGame.win_probability\` column is still populated at finalize_draft for any future analysis, but it never shows up in the UI for these games.

## What lands

**utils.py:**
- \`create_in_progress_game_embed\` — gate on \`queue.is_captain_pick\`
- \`create_condensed_in_progress_game_embed\` — gate on \`queue.is_captain_pick\`
- \`create_finished_game_embed\` — gate on \`finished_game.is_captain_pick\`
- \`create_cancelled_game_embed\` — gate on \`queue.is_captain_pick\`
- \`finished_game_str\` — gate on \`finished_game.is_captain_pick\`

**commands.py:**
- \`/sub\` flow's post-rebalance field-name overwrite now also hides win_prob for captain games (otherwise it would re-add it after the embed builder hid it)
- \`_rebalance_game\` now early-returns for captain pick games. Captain rosters are hand-picked; silently re-balancing them on a sub would violate the design.

Admin/debug helpers (\`mock_teams_str\`, \`mock_finished_game_teams_str\`) are intentionally left alone — they're not user-facing and surface mu/sigma alongside win_prob.

## Test plan

- [ ] Traditional in-progress game embed shows \`Team Name (45.3%)\`
- [ ] Captain in-progress game embed shows \`Team Name\` (no percentage)
- [ ] Same for cancelled, condensed, finished embeds
- [ ] \`/sub\` on a finalized captain game keeps the original hand-picked rosters (no rebalance), embed has no percentages
- [ ] DB column \`InProgressGame.win_probability\` is still populated for captain games (verify with a SELECT)

## Follow-ups

Last remaining task: sub-during-draft restart (task 10).