### PR TITLE
Captain pick mode: sub-during-draft restart

### DIFF
--- a/discord_bots/captain_pick.py
+++ b/discord_bots/captain_pick.py
@@ -568,6 +568,121 @@ async def finalize_draft(game_id: str) -> None:
             await move_game_players(short_uuid(game.id), None, guild)
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Sub-during-draft restart
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def restart_draft_after_sub(
+    game_id: str,
+    was_captain_subbed: bool,
+) -> None:
+    """
+    Reset a drafting game's pick state and re-prompt for first-pick choice.
+
+    Called by /sub when a substitution happens mid-draft. Per the design:
+    - Always: clear DraftPick rows, reset non-captain teams to NULL.
+    - If a captain was subbed out: also clear is_captain on all rows and
+      re-run captain selection on the new player set. The replacement
+      player isn't auto-promoted to captain — the algorithm decides who
+      the top two are from the post-sub roster.
+    - The old draft message has its view stripped (so stale buttons can't
+      be clicked) and a fresh FirstPickChoiceView is posted in its place;
+      InProgressGame.message_id is updated.
+    """
+    from discord_bots.views.draft import FirstPickChoiceView
+
+    session: SQLAlchemySession
+    with Session() as session:
+        game = (
+            session.query(InProgressGame).filter(InProgressGame.id == game_id).first()
+        )
+        if not game or not game.is_drafting:
+            return
+
+        # 1. Clear pick history.
+        session.query(DraftPick).filter(
+            DraftPick.in_progress_game_id == game_id
+        ).delete()
+
+        # 2. Reset team assignments (and captains, if needed).
+        igps: list[InProgressGamePlayer] = (
+            session.query(InProgressGamePlayer)
+            .filter(InProgressGamePlayer.in_progress_game_id == game_id)
+            .all()
+        )
+        if was_captain_subbed:
+            for igp in igps:
+                igp.team = None
+                igp.is_captain = False
+            queue: Queue | None = (
+                session.query(Queue).filter(Queue.id == game.queue_id).first()
+            )
+            if not queue:
+                return
+            player_ids = [igp.player_id for igp in igps]
+            players: list[Player] = (
+                session.query(Player).filter(Player.id.in_(player_ids)).all()
+            )
+            captain_a, captain_b = select_captains(session, players, queue, game.map_id)
+            for igp in igps:
+                if igp.player_id == captain_a.id:
+                    igp.team = 0
+                    igp.is_captain = True
+                elif igp.player_id == captain_b.id:
+                    igp.team = 1
+                    igp.is_captain = True
+        else:
+            for igp in igps:
+                if not igp.is_captain:
+                    igp.team = None
+
+        session.commit()
+
+        # 3. Strip the old draft message's view; post a fresh first-pick
+        # choice view and update message_id.
+        guild = bot.get_guild(_guild_id_for_game(game))
+        match_channel = (
+            guild.get_channel(game.channel_id) if guild and game.channel_id else None
+        )
+        if not isinstance(match_channel, TextChannel):
+            return
+
+        if game.message_id:
+            try:
+                old_message = await match_channel.fetch_message(game.message_id)
+                await old_message.edit(view=None)
+            except Exception as e:
+                _log.warning(
+                    f"[restart_draft_after_sub] couldn't disable old "
+                    f"message {game.message_id}: {e}"
+                )
+
+        captain_b_igp = (
+            session.query(InProgressGamePlayer)
+            .filter(
+                InProgressGamePlayer.in_progress_game_id == game_id,
+                InProgressGamePlayer.is_captain == True,
+                InProgressGamePlayer.team == 1,
+            )
+            .first()
+        )
+        if not captain_b_igp:
+            return
+
+        draft_cog = bot.get_cog("DraftCommands")
+        embed = create_draft_embed(session, game)
+        embed.description = (
+            "🔁 Draft restarted due to a substitution. "
+            f"<@{captain_b_igp.player_id}>, do you want to pick first or "
+            f"second?"
+        )
+        view = FirstPickChoiceView(game_id, captain_b_igp.player_id, draft_cog)
+        message = await match_channel.send(embed=embed, view=view)
+        game.message_id = message.id
+        session.commit()
+
+
 def _guild_id_for_game(game: InProgressGame) -> int:
     """
     Derive the guild_id from the bot's guilds. We don't store guild_id on

--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1596,19 +1596,66 @@ async def sub(ctx: Context, member: Member):
         )
         return
 
-    # Sub-during-draft is not yet implemented (the proper behavior is to
-    # restart the draft from scratch with the new player set; that's a
-    # follow-up). For now, block /sub on drafting games to avoid leaving the
-    # draft in a half-broken state.
+    # Sub-during-draft: do the player swap inline (preserving team/is_captain
+    # on the new IGP) and then restart the draft from scratch. The
+    # restart_draft_after_sub helper clears DraftPick rows, resets non-
+    # captain teams, re-picks captains if needed, and re-posts the
+    # FirstPickChoiceView.
     sub_target_game = caller_game or callee_game
     if sub_target_game and sub_target_game.is_drafting:
+        from discord_bots.captain_pick import restart_draft_after_sub
+
+        subbed_out_player_id = caller.id if caller_game else callee.id
+        subbed_in_player_id = callee.id if caller_game else caller.id
+        subbed_out_igp = (
+            session.query(InProgressGamePlayer)
+            .filter(
+                InProgressGamePlayer.in_progress_game_id == sub_target_game.id,
+                InProgressGamePlayer.player_id == subbed_out_player_id,
+            )
+            .first()
+        )
+        if not subbed_out_igp:
+            return
+        was_captain = subbed_out_igp.is_captain
+
+        # Ensure the subbing-in player exists in the players table.
+        if not session.query(Player).filter(Player.id == subbed_in_player_id).first():
+            subbed_in_name = (
+                callee.name if subbed_in_player_id == callee.id else caller.name
+            )
+            session.add(Player(id=subbed_in_player_id, name=subbed_in_name))
+
+        # Replace the IGP. Keep team/is_captain on the new row; if a captain
+        # was subbed, those values get overwritten when captains are re-
+        # selected by restart_draft_after_sub.
+        session.add(
+            InProgressGamePlayer(
+                in_progress_game_id=sub_target_game.id,
+                player_id=subbed_in_player_id,
+                team=subbed_out_igp.team,
+                is_captain=subbed_out_igp.is_captain,
+            )
+        )
+        session.delete(subbed_out_igp)
+        session.query(QueuePlayer).filter(
+            QueuePlayer.player_id == subbed_in_player_id
+        ).delete()
+        session.commit()
+
+        await restart_draft_after_sub(
+            sub_target_game.id, was_captain_subbed=was_captain
+        )
+
+        subbed_out_name = caller.display_name if caller_game else callee.display_name
+        subbed_in_name = callee.display_name if caller_game else caller.display_name
         await send_message(
             channel=message.channel,
             embed_description=(
-                "Substitutions during a captain pick draft aren't supported "
-                "yet. Wait for the draft to finish before subbing."
+                f"🔁 Draft restarted: {escape_markdown(subbed_in_name)} "
+                f"subbed in for {escape_markdown(subbed_out_name)}."
             ),
-            colour=Colour.red(),
+            colour=Colour.yellow(),
         )
         return
 


### PR DESCRIPTION
## Summary

Stacked on #172. Replaces the temporary block in \`/sub\` for drafting captain games with the proper restart flow described in \`docs/captain-pick-plan.md\`.

## What lands

- **\`/sub\` mid-draft** now performs the player swap inline (replacing the IGP while preserving team/is_captain) and then calls \`captain_pick.restart_draft_after_sub\`.
- **\`restart_draft_after_sub\`**:
  - Clears all \`DraftPick\` rows for the game.
  - Resets non-captain rows' \`team\` to \`NULL\`.
  - If a captain was subbed out: clears \`is_captain\` on all rows, re-runs the captain-selection algorithm on the new player set, and sets the new top two as captains. The replacement player isn't auto-promoted — the algorithm picks who's actually highest-rated post-sub.
  - Strips the view from the old draft message (so stale buttons can't be clicked) and posts a fresh \`FirstPickChoiceView\` with a "🔁 Draft restarted" header. Updates \`InProgressGame.message_id\`.
- Sends a yellow-bordered "🔁 Draft restarted: X subbed in for Y" notice in the channel where \`/sub\` was invoked.

## Test plan

- [ ] Sub a non-captain player mid-draft → all picks reset, captains keep their roles, fresh FirstPickChoiceView posted
- [ ] Sub a captain mid-draft → captains re-picked from current roster (the incoming player may or may not be a captain depending on rating)
- [ ] Old draft message's buttons no longer clickable after the restart
- [ ] After bot restart mid-restart, cog_load still works (0 picks → re-prompts FirstPickChoiceView)