### PR TITLE
fix(del): scope !del to the channel it was run in

### DIFF
--- a/discord_bots/commands.py
+++ b/discord_bots/commands.py
@@ -1108,7 +1108,10 @@ async def del_(ctx: Context, *args):
     session: SQLAlchemySession
     with Session() as session:
         queues_del_from = del_player_from_queues_and_waitlists(
-            session, ctx.author.id, *args
+            session,
+            ctx.author.id,
+            *args,
+            is_captain_pick=queue_is_captain_pick_for_channel(ctx.channel.id),
         )
         for queue in queues_del_from:
             # TODO: generify this into queue status util

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -2167,7 +2167,10 @@ async def command_autocomplete(interaction: Interaction, current: str):
 
 
 def del_player_from_queues_and_waitlists(
-    session: sqlalchemy.orm.Session, player_id: int, *args: str
+    session: sqlalchemy.orm.Session,
+    player_id: int,
+    *args: str,
+    is_captain_pick: bool | None = None,
 ) -> list[Queue]:
     queues_del_from_by_id: dict[str, Queue] = {}
     if args:
@@ -2182,6 +2185,8 @@ def del_player_from_queues_and_waitlists(
         ]
     else:
         conditions = []
+    if is_captain_pick is not None:
+        conditions.append(Queue.is_captain_pick == is_captain_pick)
     queues: List[Queue] = (
         session.query(Queue)
         .join(


### PR DESCRIPTION
## Summary
- `!del` now only removes the player from queues belonging to the same channel class (captain-pick vs traditional) as the channel where the command was invoked.
- Previously, a player queued in both the captain channel and a traditional channel would be removed from *all* their queues by a single `!del`, and the response embed listed queues from both channels.

## Why
Bug reported during captain-pick rollout: `!del` had no channel scoping, so cross-channel queueing was effectively impossible to manage from one side without affecting the other.

## How
- `del_player_from_queues_and_waitlists` gains an optional `is_captain_pick: bool | None = None` kwarg; when set, both QueuePlayer and QueueWaitlistPlayer queries filter on `Queue.is_captain_pick`.
- The `!del` handler passes `is_captain_pick=queue_is_captain_pick_for_channel(ctx.channel.id)`.
- `/admin delplayer` is intentionally left unscoped (it's documented as removing the player from all queues — admin cleanup).

## Test plan
- [ ] Player queued in both a captain-pick queue and a traditional queue runs `!del` in the traditional channel — only the traditional queue entry is removed.
- [ ] Same player runs `!del` in the captain channel — only the captain-pick queue entry is removed.
- [ ] `!del` with explicit queue name/ordinal still respects the same channel scope (no cross-channel leak).
- [ ] `/admin delplayer` still removes the player from all queues regardless of channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)