### PR TITLE
Ladder: TeamWarfareLeague-style challenge ladder

### DIFF
--- a/alembic/versions/20260426120000_b9d0a4f2c3e1_add_ladder_tables.py
+++ b/alembic/versions/20260426120000_b9d0a4f2c3e1_add_ladder_tables.py
@@ -1,0 +1,348 @@
+"""Add ladder tables
+
+Revision ID: b9d0a4f2c3e1
+Revises: 3e91c894b0a8
+Create Date: 2026-04-26 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b9d0a4f2c3e1"
+down_revision = "3e91c894b0a8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("config", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column("ladder_channel_id", sa.BigInteger(), nullable=True)
+        )
+
+    op.create_table(
+        "ladder",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("rotation_id", sa.String(), nullable=False),
+        sa.Column(
+            "maps_per_match",
+            sa.Integer(),
+            server_default=sa.text("3"),
+            nullable=False,
+        ),
+        sa.Column(
+            "max_team_size",
+            sa.Integer(),
+            server_default=sa.text("5"),
+            nullable=False,
+        ),
+        sa.Column(
+            "max_challenge_distance",
+            sa.Integer(),
+            server_default=sa.text("3"),
+            nullable=False,
+        ),
+        sa.Column(
+            "max_in_flight_per_team",
+            sa.Integer(),
+            server_default=sa.text("1"),
+            nullable=False,
+        ),
+        sa.Column("leaderboard_channel_id", sa.BigInteger(), nullable=True),
+        sa.Column("leaderboard_message_id", sa.BigInteger(), nullable=True),
+        sa.Column("history_channel_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["rotation_id"],
+            ["rotation.id"],
+            name=op.f("fk_ladder_rotation_id_rotation"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder")),
+        sa.UniqueConstraint("name", name=op.f("uq_ladder_name")),
+    )
+    with op.batch_alter_table("ladder", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_created_at"), ["created_at"], unique=False
+        )
+
+    op.create_table(
+        "ladder_team",
+        sa.Column("ladder_id", sa.String(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("captain_id", sa.BigInteger(), nullable=False),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("wins", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("losses", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("draws", sa.Integer(), server_default=sa.text("0"), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["captain_id"],
+            ["player.id"],
+            name=op.f("fk_ladder_team_captain_id_player"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["ladder_id"],
+            ["ladder.id"],
+            name=op.f("fk_ladder_team_ladder_id_ladder"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder_team")),
+        sa.UniqueConstraint(
+            "ladder_id", "name", name=op.f("uq_ladder_team_ladder_id_name")
+        ),
+        sa.UniqueConstraint(
+            "ladder_id", "position", name=op.f("uq_ladder_team_ladder_id_position")
+        ),
+    )
+    with op.batch_alter_table("ladder_team", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_ladder_id"), ["ladder_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_created_at"), ["created_at"], unique=False
+        )
+
+    op.create_table(
+        "ladder_team_player",
+        sa.Column("team_id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.BigInteger(), nullable=False),
+        sa.Column("joined_at", sa.DateTime(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["player_id"],
+            ["player.id"],
+            name=op.f("fk_ladder_team_player_player_id_player"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_id"],
+            ["ladder_team.id"],
+            name=op.f("fk_ladder_team_player_team_id_ladder_team"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder_team_player")),
+        sa.UniqueConstraint(
+            "team_id",
+            "player_id",
+            name=op.f("uq_ladder_team_player_team_id_player_id"),
+        ),
+    )
+    with op.batch_alter_table("ladder_team_player", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_player_team_id"), ["team_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_player_player_id"),
+            ["player_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_player_joined_at"),
+            ["joined_at"],
+            unique=False,
+        )
+
+    op.create_table(
+        "ladder_team_invite",
+        sa.Column("team_id", sa.String(), nullable=False),
+        sa.Column("player_id", sa.BigInteger(), nullable=False),
+        sa.Column("invited_by_id", sa.BigInteger(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["invited_by_id"],
+            ["player.id"],
+            name=op.f("fk_ladder_team_invite_invited_by_id_player"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["player_id"],
+            ["player.id"],
+            name=op.f("fk_ladder_team_invite_player_id_player"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["team_id"],
+            ["ladder_team.id"],
+            name=op.f("fk_ladder_team_invite_team_id_ladder_team"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder_team_invite")),
+        sa.UniqueConstraint(
+            "team_id",
+            "player_id",
+            name=op.f("uq_ladder_team_invite_team_id_player_id"),
+        ),
+    )
+    with op.batch_alter_table("ladder_team_invite", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_invite_team_id"), ["team_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_invite_player_id"),
+            ["player_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_team_invite_created_at"),
+            ["created_at"],
+            unique=False,
+        )
+
+    op.create_table(
+        "ladder_match",
+        sa.Column("ladder_id", sa.String(), nullable=False),
+        sa.Column("challenger_team_id", sa.String(), nullable=False),
+        sa.Column("defender_team_id", sa.String(), nullable=False),
+        sa.Column("challenger_position_at_challenge", sa.Integer(), nullable=False),
+        sa.Column("defender_position_at_challenge", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(),
+            server_default=sa.text("'pending'"),
+            nullable=False,
+        ),
+        sa.Column("winner_team_id", sa.String(), nullable=True),
+        sa.Column(
+            "challenger_map_wins",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column(
+            "defender_map_wins",
+            sa.Integer(),
+            server_default=sa.text("0"),
+            nullable=False,
+        ),
+        sa.Column("challenged_at", sa.DateTime(), nullable=True),
+        sa.Column("accepted_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["challenger_team_id"],
+            ["ladder_team.id"],
+            name=op.f("fk_ladder_match_challenger_team_id_ladder_team"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["defender_team_id"],
+            ["ladder_team.id"],
+            name=op.f("fk_ladder_match_defender_team_id_ladder_team"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["ladder_id"],
+            ["ladder.id"],
+            name=op.f("fk_ladder_match_ladder_id_ladder"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["winner_team_id"],
+            ["ladder_team.id"],
+            name=op.f("fk_ladder_match_winner_team_id_ladder_team"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder_match")),
+    )
+    with op.batch_alter_table("ladder_match", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_ladder_id"), ["ladder_id"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_challenger_team_id"),
+            ["challenger_team_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_defender_team_id"),
+            ["defender_team_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_status"), ["status"], unique=False
+        )
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_challenged_at"),
+            ["challenged_at"],
+            unique=False,
+        )
+
+    op.create_table(
+        "ladder_match_game",
+        sa.Column("match_id", sa.String(), nullable=False),
+        sa.Column("ordinal", sa.Integer(), nullable=False),
+        sa.Column("map_id", sa.String(), nullable=False),
+        sa.Column("challenger_score", sa.Integer(), nullable=True),
+        sa.Column("defender_score", sa.Integer(), nullable=True),
+        sa.Column("winner_team", sa.Integer(), nullable=True),
+        sa.Column("reported_at", sa.DateTime(), nullable=True),
+        sa.Column("reported_by_id", sa.BigInteger(), nullable=True),
+        sa.Column("id", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["map_id"],
+            ["map.id"],
+            name=op.f("fk_ladder_match_game_map_id_map"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["match_id"],
+            ["ladder_match.id"],
+            name=op.f("fk_ladder_match_game_match_id_ladder_match"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["reported_by_id"],
+            ["player.id"],
+            name=op.f("fk_ladder_match_game_reported_by_id_player"),
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_ladder_match_game")),
+        sa.UniqueConstraint(
+            "match_id",
+            "ordinal",
+            name=op.f("uq_ladder_match_game_match_id_ordinal"),
+        ),
+    )
+    with op.batch_alter_table("ladder_match_game", schema=None) as batch_op:
+        batch_op.create_index(
+            batch_op.f("ix_ladder_match_game_match_id"),
+            ["match_id"],
+            unique=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("ladder_match_game", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_match_game_match_id"))
+    op.drop_table("ladder_match_game")
+
+    with op.batch_alter_table("ladder_match", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_match_challenged_at"))
+        batch_op.drop_index(batch_op.f("ix_ladder_match_status"))
+        batch_op.drop_index(batch_op.f("ix_ladder_match_defender_team_id"))
+        batch_op.drop_index(batch_op.f("ix_ladder_match_challenger_team_id"))
+        batch_op.drop_index(batch_op.f("ix_ladder_match_ladder_id"))
+    op.drop_table("ladder_match")
+
+    with op.batch_alter_table("ladder_team_invite", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_team_invite_created_at"))
+        batch_op.drop_index(batch_op.f("ix_ladder_team_invite_player_id"))
+        batch_op.drop_index(batch_op.f("ix_ladder_team_invite_team_id"))
+    op.drop_table("ladder_team_invite")
+
+    with op.batch_alter_table("ladder_team_player", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_team_player_joined_at"))
+        batch_op.drop_index(batch_op.f("ix_ladder_team_player_player_id"))
+        batch_op.drop_index(batch_op.f("ix_ladder_team_player_team_id"))
+    op.drop_table("ladder_team_player")
+
+    with op.batch_alter_table("ladder_team", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_team_created_at"))
+        batch_op.drop_index(batch_op.f("ix_ladder_team_ladder_id"))
+    op.drop_table("ladder_team")
+
+    with op.batch_alter_table("ladder", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_ladder_created_at"))
+    op.drop_table("ladder")
+
+    with op.batch_alter_table("config", schema=None) as batch_op:
+        batch_op.drop_column("ladder_channel_id")

--- a/discord_bots/checks.py
+++ b/discord_bots/checks.py
@@ -12,6 +12,8 @@ from .models import AdminRole, Config, Player, Session
 
 _captain_channel_id_cache: int | None = None
 _captain_channel_id_cache_loaded: bool = False
+_ladder_channel_id_cache: int | None = None
+_ladder_channel_id_cache_loaded: bool = False
 
 
 def _load_captain_channel_id_cache() -> None:
@@ -34,6 +36,26 @@ def update_captain_channel_id_cache(value: int | None) -> None:
     global _captain_channel_id_cache, _captain_channel_id_cache_loaded
     _captain_channel_id_cache = value
     _captain_channel_id_cache_loaded = True
+
+
+def _load_ladder_channel_id_cache() -> None:
+    global _ladder_channel_id_cache, _ladder_channel_id_cache_loaded
+    with Session() as session:
+        config_row = session.query(Config).first()
+        _ladder_channel_id_cache = config_row.ladder_channel_id if config_row else None
+    _ladder_channel_id_cache_loaded = True
+
+
+def get_cached_ladder_channel_id() -> int | None:
+    if not _ladder_channel_id_cache_loaded:
+        _load_ladder_channel_id_cache()
+    return _ladder_channel_id_cache
+
+
+def update_ladder_channel_id_cache(value: int | None) -> None:
+    global _ladder_channel_id_cache, _ladder_channel_id_cache_loaded
+    _ladder_channel_id_cache = value
+    _ladder_channel_id_cache_loaded = True
 
 
 def queue_is_captain_pick_for_channel(channel_id: int) -> bool:
@@ -208,6 +230,35 @@ async def is_command_or_captain_channel(interaction: Interaction) -> bool:
     description = "Interactions must be performed from the command channel"
     if get_cached_captain_channel_id() is not None:
         description += " or the captain channel"
+    embed = Embed(description=description, colour=Colour.red())
+    if not interaction.response.is_done():
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+    else:
+        await interaction.followup.send(embed=embed, ephemeral=True)
+    return False
+
+
+async def is_ladder_channel(interaction: Interaction) -> bool:
+    """
+    Check that interactions are performed from the registered ladder channel
+    (Config.ladder_channel_id). Returns False with a friendly error if no
+    ladder channel is configured.
+    """
+    ladder_channel_id = get_cached_ladder_channel_id()
+    if (
+        ladder_channel_id is not None
+        and interaction.channel
+        and interaction.channel.id == ladder_channel_id
+    ):
+        return True
+
+    if ladder_channel_id is None:
+        description = (
+            "No ladder channel is configured. An admin must set one with "
+            "`/config setladderchannel`."
+        )
+    else:
+        description = "Ladder commands must be used in the ladder channel."
     embed = Embed(description=description, colour=Colour.red())
     if not interaction.response.is_done():
         await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/discord_bots/cogs/config.py
+++ b/discord_bots/cogs/config.py
@@ -9,6 +9,7 @@ from discord_bots.checks import (
     is_admin_app_command,
     is_command_or_captain_channel,
     update_captain_channel_id_cache,
+    update_ladder_channel_id_cache,
 )
 from discord_bots.models import Config, Session
 
@@ -133,6 +134,16 @@ class ConfigCommands(commands.Cog):
                 value=captain_channel_value,
                 inline=True,
             )
+            ladder_channel_value = (
+                f"<#{config.ladder_channel_id}>"
+                if config.ladder_channel_id
+                else "`Not set`"
+            )
+            embed.add_field(
+                name="Ladder channel",
+                value=ladder_channel_value,
+                inline=True,
+            )
 
             await interaction.response.send_message(embed=embed)
 
@@ -235,6 +246,57 @@ class ConfigCommands(commands.Cog):
 
         embed = Embed(
             description=f"Captain channel cleared by <@{interaction.user.id}>",
+            colour=Colour.green(),
+        )
+        await interaction.response.send_message(embed=embed)
+        if env_config.ADMIN_LOG_CHANNEL:
+            admin_log_channel = bot.get_channel(env_config.ADMIN_LOG_CHANNEL)
+            if isinstance(admin_log_channel, TextChannel):
+                await admin_log_channel.send(embed=embed)
+
+    @group.command(
+        name="setladderchannel",
+        description="Register a channel as the ladder lobby",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_command_or_captain_channel)
+    @app_commands.describe(channel="Channel to register as the ladder lobby")
+    async def setladderchannel(self, interaction: Interaction, channel: TextChannel):
+        with Session() as session:
+            config = session.query(Config).first()
+            config.ladder_channel_id = channel.id
+            session.commit()
+        update_ladder_channel_id_cache(channel.id)
+
+        embed = Embed(
+            description=(
+                f"Ladder channel set to {channel.mention} by "
+                f"<@{interaction.user.id}>. Ladder commands can now be used "
+                f"there."
+            ),
+            colour=Colour.green(),
+        )
+        await interaction.response.send_message(embed=embed)
+        if env_config.ADMIN_LOG_CHANNEL:
+            admin_log_channel = bot.get_channel(env_config.ADMIN_LOG_CHANNEL)
+            if isinstance(admin_log_channel, TextChannel):
+                await admin_log_channel.send(embed=embed)
+
+    @group.command(
+        name="clearladderchannel",
+        description="Unregister the ladder lobby channel",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_command_or_captain_channel)
+    async def clearladderchannel(self, interaction: Interaction):
+        with Session() as session:
+            config = session.query(Config).first()
+            config.ladder_channel_id = None
+            session.commit()
+        update_ladder_channel_id_cache(None)
+
+        embed = Embed(
+            description=f"Ladder channel cleared by <@{interaction.user.id}>",
             colour=Colour.green(),
         )
         await interaction.response.send_message(embed=embed)

--- a/discord_bots/cogs/ladder.py
+++ b/discord_bots/cogs/ladder.py
@@ -1,0 +1,380 @@
+import logging
+
+from discord import Colour, Embed, Interaction, TextChannel, app_commands
+from discord.ext.commands import Bot
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.session import Session as SQLAlchemySession
+
+from discord_bots.checks import is_admin_app_command, is_ladder_channel
+from discord_bots.cogs.base import BaseCog
+from discord_bots.models import Ladder, Rotation, Session
+from discord_bots.utils import ladder_autocomplete, rotation_autocomplete
+
+_log = logging.getLogger(__name__)
+
+MAX_MAPS_PER_MATCH = 5
+
+
+class LadderCommands(BaseCog):
+    def __init__(self, bot: Bot):
+        super().__init__(bot)
+
+    ladder_group = app_commands.Group(
+        name="ladder", description="Challenge ladder commands"
+    )
+    admin_group = app_commands.Group(
+        name="admin", parent=ladder_group, description="Ladder admin commands"
+    )
+
+    @ladder_group.command(name="list", description="List all ladders")
+    @app_commands.check(is_ladder_channel)
+    async def list_ladders(self, interaction: Interaction):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladders: list[Ladder] = session.query(Ladder).order_by(Ladder.name).all()
+            if not ladders:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description="No ladders configured.",
+                        colour=Colour.blue(),
+                    )
+                )
+                return
+
+            embed = Embed(title="Ladders", colour=Colour.blue())
+            for ladder in ladders:
+                rotation: Rotation | None = (
+                    session.query(Rotation)
+                    .filter(Rotation.id == ladder.rotation_id)
+                    .first()
+                )
+                rotation_name = rotation.name if rotation else "(missing)"
+                lines = [
+                    f"Rotation: **{rotation_name}**",
+                    f"Maps per match: **{ladder.maps_per_match}**",
+                    f"Max team size: **{ladder.max_team_size}**",
+                    f"Challenge distance: **{ladder.max_challenge_distance}**",
+                    f"Active: **{ladder.is_active}**",
+                ]
+                embed.add_field(name=ladder.name, value="\n".join(lines), inline=False)
+            await interaction.response.send_message(embed=embed)
+
+    @admin_group.command(name="create", description="Create a new ladder")
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.describe(
+        name="Unique ladder name",
+        rotation="Existing rotation that supplies maps for matches",
+        maps_per_match=f"Number of maps per match (1-{MAX_MAPS_PER_MATCH})",
+        max_team_size="Required roster size for matches",
+    )
+    @app_commands.autocomplete(rotation=rotation_autocomplete)
+    async def create_ladder(
+        self,
+        interaction: Interaction,
+        name: str,
+        rotation: str,
+        maps_per_match: int,
+        max_team_size: int,
+    ):
+        if maps_per_match < 1 or maps_per_match > MAX_MAPS_PER_MATCH:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(
+                        f"`maps_per_match` must be between 1 and "
+                        f"{MAX_MAPS_PER_MATCH}."
+                    ),
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+        if max_team_size < 1:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="`max_team_size` must be at least 1.",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+
+        session: SQLAlchemySession
+        with Session() as session:
+            rotation_row: Rotation | None = (
+                session.query(Rotation).filter(Rotation.name == rotation).first()
+            )
+            if not rotation_row:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Rotation **{rotation}** not found.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            try:
+                ladder = Ladder(
+                    name=name,
+                    rotation_id=rotation_row.id,
+                    maps_per_match=maps_per_match,
+                    max_team_size=max_team_size,
+                )
+                session.add(ladder)
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Ladder **{name}** already exists.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(
+                        f"Ladder **{name}** created on rotation "
+                        f"**{rotation}** with {maps_per_match} maps per "
+                        f"match and team size {max_team_size}."
+                    ),
+                    colour=Colour.green(),
+                )
+            )
+
+    @admin_group.command(name="delete", description="Delete a ladder")
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.describe(ladder="Ladder to delete")
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    async def delete_ladder(self, interaction: Interaction, ladder: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row: Ladder | None = (
+                session.query(Ladder).filter(Ladder.name == ladder).first()
+            )
+            if not ladder_row:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Ladder **{ladder}** not found.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            session.delete(ladder_row)
+            session.commit()
+
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=f"Ladder **{ladder}** deleted.",
+                    colour=Colour.green(),
+                )
+            )
+
+    @admin_group.command(
+        name="setchannels",
+        description="Set leaderboard and history channels for a ladder",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.describe(
+        ladder="Ladder to configure",
+        leaderboard_channel="Channel where the leaderboard message will be posted",
+        history_channel="Channel where match history will be posted",
+    )
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    async def set_channels(
+        self,
+        interaction: Interaction,
+        ladder: str,
+        leaderboard_channel: TextChannel,
+        history_channel: TextChannel,
+    ):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row: Ladder | None = (
+                session.query(Ladder).filter(Ladder.name == ladder).first()
+            )
+            if not ladder_row:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Ladder **{ladder}** not found.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            ladder_row.leaderboard_channel_id = leaderboard_channel.id
+            ladder_row.leaderboard_message_id = None
+            ladder_row.history_channel_id = history_channel.id
+            session.commit()
+
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(
+                        f"Ladder **{ladder}** channels set. "
+                        f"Leaderboard: {leaderboard_channel.mention}, "
+                        f"History: {history_channel.mention}."
+                    ),
+                    colour=Colour.green(),
+                )
+            )
+
+    @admin_group.command(
+        name="setmapspermatch",
+        description="Set the number of maps per match for a ladder",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(
+        ladder="Ladder to configure",
+        value=f"Maps per match (1-{MAX_MAPS_PER_MATCH})",
+    )
+    async def set_maps_per_match(
+        self, interaction: Interaction, ladder: str, value: int
+    ):
+        if value < 1 or value > MAX_MAPS_PER_MATCH:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(
+                        f"`maps_per_match` must be between 1 and "
+                        f"{MAX_MAPS_PER_MATCH}."
+                    ),
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+        await self._set_int_field(
+            interaction, ladder, "maps_per_match", value, "Maps per match"
+        )
+
+    @admin_group.command(
+        name="setmaxteamsize",
+        description="Set the required roster size for a ladder",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder to configure", value="Roster size")
+    async def set_max_team_size(
+        self, interaction: Interaction, ladder: str, value: int
+    ):
+        if value < 1:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="`max_team_size` must be at least 1.",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+        await self._set_int_field(
+            interaction, ladder, "max_team_size", value, "Max team size"
+        )
+
+    @admin_group.command(
+        name="setchallengedistance",
+        description="Set the maximum challenge distance for a ladder",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(
+        ladder="Ladder to configure",
+        value="Max positions a team may challenge above itself",
+    )
+    async def set_challenge_distance(
+        self, interaction: Interaction, ladder: str, value: int
+    ):
+        if value < 1:
+            await interaction.response.send_message(
+                embed=Embed(
+                    description="`max_challenge_distance` must be at least 1.",
+                    colour=Colour.red(),
+                ),
+                ephemeral=True,
+            )
+            return
+        await self._set_int_field(
+            interaction,
+            ladder,
+            "max_challenge_distance",
+            value,
+            "Max challenge distance",
+        )
+
+    @admin_group.command(
+        name="setactive",
+        description="Enable or disable writes for a ladder",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder to configure", value="True or False")
+    async def set_active(self, interaction: Interaction, ladder: str, value: bool):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row: Ladder | None = (
+                session.query(Ladder).filter(Ladder.name == ladder).first()
+            )
+            if not ladder_row:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Ladder **{ladder}** not found.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            ladder_row.is_active = value
+            session.commit()
+
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(f"Ladder **{ladder}** is_active set to **{value}**."),
+                    colour=Colour.green(),
+                )
+            )
+
+    async def _set_int_field(
+        self,
+        interaction: Interaction,
+        ladder_name: str,
+        column: str,
+        value: int,
+        display_name: str,
+    ) -> None:
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row: Ladder | None = (
+                session.query(Ladder).filter(Ladder.name == ladder_name).first()
+            )
+            if not ladder_row:
+                await interaction.response.send_message(
+                    embed=Embed(
+                        description=f"Ladder **{ladder_name}** not found.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            setattr(ladder_row, column, value)
+            session.commit()
+
+            await interaction.response.send_message(
+                embed=Embed(
+                    description=(
+                        f"Ladder **{ladder_name}** {display_name} set to "
+                        f"**{value}**."
+                    ),
+                    colour=Colour.green(),
+                )
+            )

--- a/discord_bots/cogs/ladder.py
+++ b/discord_bots/cogs/ladder.py
@@ -1,4 +1,6 @@
 import logging
+import random
+from datetime import datetime, timezone
 
 from discord import Colour, Embed, Interaction, Member, TextChannel, app_commands
 from discord.ext.commands import Bot
@@ -7,16 +9,20 @@ from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
+from discord_bots.bot import bot as discord_bot
 from discord_bots.checks import is_admin_app_command, is_ladder_channel
 from discord_bots.cogs.base import BaseCog
 from discord_bots.models import (
     Ladder,
     LadderMatch,
+    LadderMatchGame,
     LadderTeam,
     LadderTeamInvite,
     LadderTeamPlayer,
+    Map,
     Player,
     Rotation,
+    RotationMap,
     Session,
 )
 from discord_bots.utils import (
@@ -98,6 +104,157 @@ def _next_position(session: SQLAlchemySession, ladder_id: str) -> int:
         .scalar()
     )
     return (max_pos or 0) + 1
+
+
+def _team_in_flight_match(
+    session: SQLAlchemySession, team_id: str
+) -> LadderMatch | None:
+    return (
+        session.query(LadderMatch)
+        .filter(
+            LadderMatch.status.in_(IN_FLIGHT_STATUSES),
+            (LadderMatch.challenger_team_id == team_id)
+            | (LadderMatch.defender_team_id == team_id),
+        )
+        .first()
+    )
+
+
+def _team_outgoing_pending(
+    session: SQLAlchemySession, team_id: str
+) -> LadderMatch | None:
+    return (
+        session.query(LadderMatch)
+        .filter(
+            LadderMatch.status == "pending",
+            LadderMatch.challenger_team_id == team_id,
+        )
+        .first()
+    )
+
+
+def _team_incoming_pending(
+    session: SQLAlchemySession, team_id: str
+) -> LadderMatch | None:
+    return (
+        session.query(LadderMatch)
+        .filter(
+            LadderMatch.status == "pending",
+            LadderMatch.defender_team_id == team_id,
+        )
+        .first()
+    )
+
+
+def _utc_now_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+async def _post_history(ladder: Ladder, embed: Embed) -> None:
+    """Post an embed to the ladder's history channel, if configured."""
+    if not ladder.history_channel_id:
+        return
+    channel = discord_bot.get_channel(ladder.history_channel_id)
+    if isinstance(channel, TextChannel):
+        try:
+            await channel.send(embed=embed)
+        except Exception:
+            _log.exception(
+                "Failed to post to ladder history channel %s", ladder.history_channel_id
+            )
+
+
+def _build_leaderboard_embed(session: SQLAlchemySession, ladder: Ladder) -> Embed:
+    teams: list[LadderTeam] = (
+        session.query(LadderTeam)
+        .filter(LadderTeam.ladder_id == ladder.id)
+        .order_by(LadderTeam.position)
+        .all()
+    )
+
+    # Pre-fetch team-name lookup for opponent annotations.
+    team_by_id = {t.id: t for t in teams}
+
+    in_flight: list[LadderMatch] = (
+        session.query(LadderMatch)
+        .filter(
+            LadderMatch.ladder_id == ladder.id,
+            LadderMatch.status.in_(IN_FLIGHT_STATUSES),
+        )
+        .all()
+    )
+    annotation_by_team: dict[str, str] = {}
+    for match in in_flight:
+        challenger = team_by_id.get(match.challenger_team_id)
+        defender = team_by_id.get(match.defender_team_id)
+        if not challenger or not defender:
+            continue
+        if match.status == "pending":
+            annotation_by_team[challenger.id] = f"[challenging {defender.name}]"
+            annotation_by_team[defender.id] = f"[challenged by {challenger.name}]"
+        else:
+            annotation_by_team[challenger.id] = (
+                f"[challenge accepted vs {defender.name}]"
+            )
+            annotation_by_team[defender.id] = (
+                f"[challenge accepted vs {challenger.name}]"
+            )
+
+    if not teams:
+        body = "*No teams yet.*"
+    else:
+        lines = []
+        for t in teams:
+            ann = annotation_by_team.get(t.id, "")
+            line = (
+                f"`{t.position:>2}.` **{escape_markdown(t.name)}** "
+                f"— {t.wins}-{t.losses}-{t.draws}"
+            )
+            if ann:
+                line += f"  {ann}"
+            lines.append(line)
+        body = "\n".join(lines)
+
+    header = (
+        f"maps/match: **{ladder.maps_per_match}**   "
+        f"roster: **{ladder.max_team_size}**   "
+        f"challenge range: **{ladder.max_challenge_distance}**"
+    )
+    embed = Embed(
+        title=f"Ladder: {ladder.name}",
+        description=f"{header}\n\n{body}",
+        colour=Colour.gold(),
+    )
+    return embed
+
+
+async def _refresh_leaderboard(ladder: Ladder) -> None:
+    """Edit (or post) the per-ladder leaderboard message."""
+    if not ladder.leaderboard_channel_id:
+        return
+    channel = discord_bot.get_channel(ladder.leaderboard_channel_id)
+    if not isinstance(channel, TextChannel):
+        return
+    with Session() as session:
+        # Re-fetch ladder to ensure fresh state for the embed.
+        fresh = session.query(Ladder).filter(Ladder.id == ladder.id).first()
+        if not fresh:
+            return
+        embed = _build_leaderboard_embed(session, fresh)
+        try:
+            if fresh.leaderboard_message_id:
+                try:
+                    msg = await channel.fetch_message(fresh.leaderboard_message_id)
+                    await msg.edit(embed=embed)
+                    return
+                except Exception:
+                    # Fall through to send a new message.
+                    pass
+            sent = await channel.send(embed=embed)
+            fresh.leaderboard_message_id = sent.id
+            session.commit()
+        except Exception:
+            _log.exception("Failed to refresh ladder leaderboard for %s", ladder.name)
 
 
 async def _err(interaction: Interaction, msg: str) -> None:
@@ -1089,3 +1246,374 @@ class LadderCommands(BaseCog):
         )
         for team in below:
             team.position -= 1
+
+    # ------------------------------------------------------------------
+    # Challenge / accept / decline / cancel
+    # ------------------------------------------------------------------
+
+    @ladder_group.command(
+        name="challenge", description="Challenge another team to a match"
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, opponent=ladder_team_autocomplete
+    )
+    @app_commands.describe(ladder="Ladder", opponent="Team to challenge")
+    async def challenge(self, interaction: Interaction, ladder: str, opponent: str):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+
+            challenger = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not challenger:
+                await _err(interaction, "You are not on a team in this ladder.")
+                return
+            if challenger.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can issue challenges.")
+                return
+            defender = _find_team(session, ladder_row.id, opponent)
+            if not defender:
+                await _err(
+                    interaction, f"Team **{opponent}** not found in this ladder."
+                )
+                return
+            if defender.id == challenger.id:
+                await _err(interaction, "You can't challenge your own team.")
+                return
+
+            if defender.position >= challenger.position:
+                await _err(
+                    interaction,
+                    "You can only challenge teams ranked above yours.",
+                )
+                return
+            distance = challenger.position - defender.position
+            if distance > ladder_row.max_challenge_distance:
+                await _err(
+                    interaction,
+                    (
+                        f"Defender is {distance} positions above you. "
+                        f"Max challenge distance is "
+                        f"{ladder_row.max_challenge_distance}."
+                    ),
+                )
+                return
+
+            for team, label in (
+                (challenger, "Your team"),
+                (defender, "The defender"),
+            ):
+                roster_size = _team_roster_size(session, team.id)
+                if roster_size < ladder_row.max_team_size:
+                    await _err(
+                        interaction,
+                        (
+                            f"{label} ({team.name}) has {roster_size}/"
+                            f"{ladder_row.max_team_size} players. Both rosters "
+                            f"must be full to challenge."
+                        ),
+                    )
+                    return
+                in_flight = _team_in_flight_match(session, team.id)
+                if in_flight:
+                    await _err(
+                        interaction,
+                        (f"{label} ({team.name}) already has an in-flight " f"match."),
+                    )
+                    return
+
+            match = LadderMatch(
+                ladder_id=ladder_row.id,
+                challenger_team_id=challenger.id,
+                defender_team_id=defender.id,
+                challenger_position_at_challenge=challenger.position,
+                defender_position_at_challenge=defender.position,
+            )
+            session.add(match)
+            session.commit()
+
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            history_embed = Embed(
+                title="Challenge issued",
+                description=(
+                    f"**{escape_markdown(challenger.name)}** "
+                    f"(#{challenger.position}) challenges "
+                    f"**{escape_markdown(defender.name)}** "
+                    f"(#{defender.position}) on ladder "
+                    f"**{ladder_row.name}**."
+                ),
+                colour=Colour.orange(),
+            )
+            await _ok(
+                interaction,
+                (
+                    f"Challenge sent to **{escape_markdown(defender.name)}**. "
+                    f"Their captain can `/ladder team accept` or `decline`."
+                ),
+            )
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @ladder_group.command(
+        name="accept",
+        description="Accept the pending challenge against your team",
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def accept(self, interaction: Interaction, ladder: str):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(
+                    interaction,
+                    "Only the team captain can accept challenges.",
+                )
+                return
+            match = _team_incoming_pending(session, team.id)
+            if not match:
+                await _err(
+                    interaction,
+                    "Your team has no pending challenge to accept.",
+                )
+                return
+
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            if not challenger:
+                await _err(interaction, "Challenger team is missing.")
+                return
+
+            for t in (team, challenger):
+                if _team_roster_size(session, t.id) < ladder_row.max_team_size:
+                    await _err(
+                        interaction,
+                        (
+                            f"Team **{t.name}** is below the roster cap. "
+                            f"Match cannot start until both teams are full."
+                        ),
+                    )
+                    return
+
+            rotation_pairs: list[tuple[RotationMap, Map]] = (
+                session.query(RotationMap, Map)
+                .join(Map, Map.id == RotationMap.map_id)
+                .filter(RotationMap.rotation_id == ladder_row.rotation_id)
+                .all()
+            )
+            map_options: list[Map] = [m for _, m in rotation_pairs]
+            if not map_options:
+                await _err(
+                    interaction,
+                    (
+                        "The ladder's rotation has no maps. Add maps to the "
+                        "rotation before accepting challenges."
+                    ),
+                )
+                return
+
+            duplicates_used = False
+            if len(map_options) >= ladder_row.maps_per_match:
+                chosen_maps = random.sample(map_options, k=ladder_row.maps_per_match)
+            else:
+                chosen_maps = random.choices(map_options, k=ladder_row.maps_per_match)
+                duplicates_used = True
+
+            for ordinal, m in enumerate(chosen_maps, start=1):
+                session.add(
+                    LadderMatchGame(
+                        match_id=match.id,
+                        ordinal=ordinal,
+                        map_id=m.id,
+                    )
+                )
+
+            match.status = "accepted"
+            match.accepted_at = _utc_now_naive()
+            session.commit()
+
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            map_list = "\n".join(
+                f"{i}. {escape_markdown(m.full_name)}"
+                for i, m in enumerate(chosen_maps, start=1)
+            )
+            history_embed = Embed(
+                title="Match accepted",
+                description=(
+                    f"**{escape_markdown(challenger.name)}** vs "
+                    f"**{escape_markdown(team.name)}** on ladder "
+                    f"**{ladder_row.name}**.\n\nMaps:\n{map_list}"
+                ),
+                colour=Colour.green(),
+            )
+            if duplicates_used:
+                history_embed.add_field(
+                    name="Note",
+                    value=(
+                        "Rotation has fewer maps than `maps_per_match`; "
+                        "duplicates were allowed."
+                    ),
+                    inline=False,
+                )
+            await _ok(
+                interaction,
+                (
+                    f"Challenge accepted. Maps:\n{map_list}\n\nWhen all maps "
+                    f"are played, either captain can run `/ladder report`."
+                ),
+            )
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @ladder_group.command(
+        name="decline",
+        description="Decline the pending challenge against your team",
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def decline(self, interaction: Interaction, ladder: str):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(
+                    interaction,
+                    "Only the team captain can decline challenges.",
+                )
+                return
+            match = _team_incoming_pending(session, team.id)
+            if not match:
+                await _err(interaction, "Your team has no pending challenge.")
+                return
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            match.status = "cancelled"
+            match.completed_at = _utc_now_naive()
+            session.commit()
+
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            history_embed = Embed(
+                title="Challenge declined",
+                description=(
+                    f"**{escape_markdown(team.name)}** declined a challenge "
+                    f"from **{escape_markdown(challenger.name) if challenger else '(missing)'}** "
+                    f"on ladder **{ladder_row.name}**."
+                ),
+                colour=Colour.dark_grey(),
+            )
+            await _ok(interaction, "Challenge declined.")
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @ladder_group.command(
+        name="cancel",
+        description="Cancel your team's outgoing pending challenge",
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def cancel(self, interaction: Interaction, ladder: str):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(
+                    interaction,
+                    "Only the team captain can cancel challenges.",
+                )
+                return
+            match = _team_outgoing_pending(session, team.id)
+            if not match:
+                await _err(
+                    interaction,
+                    "Your team has no outgoing pending challenge.",
+                )
+                return
+            defender = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            match.status = "cancelled"
+            match.completed_at = _utc_now_naive()
+            session.commit()
+
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            history_embed = Embed(
+                title="Challenge cancelled",
+                description=(
+                    f"**{escape_markdown(team.name)}** cancelled their "
+                    f"challenge to **{escape_markdown(defender.name) if defender else '(missing)'}** "
+                    f"on ladder **{ladder_row.name}**."
+                ),
+                colour=Colour.dark_grey(),
+            )
+            await _ok(interaction, "Challenge cancelled.")
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)

--- a/discord_bots/cogs/ladder.py
+++ b/discord_bots/cogs/ladder.py
@@ -1,18 +1,119 @@
 import logging
 
-from discord import Colour, Embed, Interaction, TextChannel, app_commands
+from discord import Colour, Embed, Interaction, Member, TextChannel, app_commands
 from discord.ext.commands import Bot
+from discord.utils import escape_markdown
+from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm.session import Session as SQLAlchemySession
 
 from discord_bots.checks import is_admin_app_command, is_ladder_channel
 from discord_bots.cogs.base import BaseCog
-from discord_bots.models import Ladder, Rotation, Session
-from discord_bots.utils import ladder_autocomplete, rotation_autocomplete
+from discord_bots.models import (
+    Ladder,
+    LadderMatch,
+    LadderTeam,
+    LadderTeamInvite,
+    LadderTeamPlayer,
+    Player,
+    Rotation,
+    Session,
+)
+from discord_bots.utils import (
+    ladder_autocomplete,
+    ladder_team_autocomplete,
+    rotation_autocomplete,
+)
 
 _log = logging.getLogger(__name__)
 
 MAX_MAPS_PER_MATCH = 5
+IN_FLIGHT_STATUSES = ("pending", "accepted")
+
+
+def _ensure_player(session: SQLAlchemySession, member: Member) -> Player:
+    """Look up a Player row by Discord member, creating it if missing."""
+    player: Player | None = session.query(Player).filter(Player.id == member.id).first()
+    if not player:
+        player = Player(id=member.id, name=member.name)
+        session.add(player)
+        session.flush()
+    return player
+
+
+def _find_ladder(session: SQLAlchemySession, name: str) -> Ladder | None:
+    return session.query(Ladder).filter(Ladder.name == name).first()
+
+
+def _find_team(
+    session: SQLAlchemySession, ladder_id: str, name: str
+) -> LadderTeam | None:
+    return (
+        session.query(LadderTeam)
+        .filter(LadderTeam.ladder_id == ladder_id, LadderTeam.name == name)
+        .first()
+    )
+
+
+def _find_player_team_in_ladder(
+    session: SQLAlchemySession, ladder_id: str, player_id: int
+) -> LadderTeam | None:
+    return (
+        session.query(LadderTeam)
+        .join(LadderTeamPlayer, LadderTeamPlayer.team_id == LadderTeam.id)
+        .filter(
+            LadderTeam.ladder_id == ladder_id,
+            LadderTeamPlayer.player_id == player_id,
+        )
+        .first()
+    )
+
+
+def _team_roster_size(session: SQLAlchemySession, team_id: str) -> int:
+    return (
+        session.query(func.count(LadderTeamPlayer.id))
+        .filter(LadderTeamPlayer.team_id == team_id)
+        .scalar()
+        or 0
+    )
+
+
+def _team_has_in_flight_match(session: SQLAlchemySession, team_id: str) -> bool:
+    return (
+        session.query(LadderMatch.id)
+        .filter(
+            LadderMatch.status.in_(IN_FLIGHT_STATUSES),
+            (LadderMatch.challenger_team_id == team_id)
+            | (LadderMatch.defender_team_id == team_id),
+        )
+        .first()
+        is not None
+    )
+
+
+def _next_position(session: SQLAlchemySession, ladder_id: str) -> int:
+    max_pos = (
+        session.query(func.max(LadderTeam.position))
+        .filter(LadderTeam.ladder_id == ladder_id)
+        .scalar()
+    )
+    return (max_pos or 0) + 1
+
+
+async def _err(interaction: Interaction, msg: str) -> None:
+    embed = Embed(description=msg, colour=Colour.red())
+    if not interaction.response.is_done():
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+    else:
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+async def _ok(interaction: Interaction, msg: str, ephemeral: bool = False) -> None:
+    embed = Embed(description=msg, colour=Colour.green())
+    if not interaction.response.is_done():
+        await interaction.response.send_message(embed=embed, ephemeral=ephemeral)
+    else:
+        await interaction.followup.send(embed=embed, ephemeral=ephemeral)
 
 
 class LadderCommands(BaseCog):
@@ -24,6 +125,9 @@ class LadderCommands(BaseCog):
     )
     admin_group = app_commands.Group(
         name="admin", parent=ladder_group, description="Ladder admin commands"
+    )
+    team_group = app_commands.Group(
+        name="team", parent=ladder_group, description="Ladder team commands"
     )
 
     @ladder_group.command(name="list", description="List all ladders")
@@ -378,3 +482,610 @@ class LadderCommands(BaseCog):
                     colour=Colour.green(),
                 )
             )
+
+    # ------------------------------------------------------------------
+    # Team commands
+    # ------------------------------------------------------------------
+
+    @team_group.command(
+        name="create", description="Create a new ladder team (you become captain)"
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder to create the team in", name="Team name")
+    async def team_create(self, interaction: Interaction, ladder: str, name: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+
+            existing = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if existing:
+                await _err(
+                    interaction,
+                    f"You are already on team **{existing.name}** in this ladder.",
+                )
+                return
+
+            captain = _ensure_player(session, interaction.user)
+            position = _next_position(session, ladder_row.id)
+
+            try:
+                team = LadderTeam(
+                    ladder_id=ladder_row.id,
+                    name=name,
+                    captain_id=captain.id,
+                    position=position,
+                )
+                session.add(team)
+                session.flush()
+                session.add(LadderTeamPlayer(team_id=team.id, player_id=captain.id))
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                await _err(
+                    interaction, f"Team **{name}** already exists in this ladder."
+                )
+                return
+
+            await _ok(
+                interaction,
+                (
+                    f"Team **{escape_markdown(name)}** created in ladder "
+                    f"**{ladder}** at position {position}. You are the captain."
+                ),
+            )
+
+    @team_group.command(name="invite", description="Invite a player to your team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder", member="Player to invite")
+    async def team_invite(self, interaction: Interaction, ladder: str, member: Member):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team:
+                await _err(interaction, "You are not on a team in this ladder.")
+                return
+            if team.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can invite players.")
+                return
+
+            roster_size = _team_roster_size(session, team.id)
+            if roster_size >= ladder_row.max_team_size:
+                await _err(
+                    interaction,
+                    (
+                        f"Team is at the roster cap "
+                        f"({ladder_row.max_team_size}). Kick someone first."
+                    ),
+                )
+                return
+
+            invitee = _ensure_player(session, member)
+            if invitee.id == interaction.user.id:
+                await _err(interaction, "You can't invite yourself.")
+                return
+
+            existing_team = _find_player_team_in_ladder(
+                session, ladder_row.id, invitee.id
+            )
+            if existing_team:
+                await _err(
+                    interaction,
+                    (
+                        f"{escape_markdown(member.name)} is already on team "
+                        f"**{existing_team.name}** in this ladder."
+                    ),
+                )
+                return
+
+            try:
+                session.add(
+                    LadderTeamInvite(
+                        team_id=team.id,
+                        player_id=invitee.id,
+                        invited_by_id=interaction.user.id,
+                    )
+                )
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                await _err(
+                    interaction,
+                    (
+                        f"{escape_markdown(member.name)} already has a pending "
+                        f"invite to **{team.name}**."
+                    ),
+                )
+                return
+
+            await _ok(
+                interaction,
+                (
+                    f"Invited {member.mention} to **{escape_markdown(team.name)}**. "
+                    f"They can accept with `/ladder team accept ladder:{ladder} "
+                    f"team_name:{team.name}`."
+                ),
+            )
+
+    @team_group.command(
+        name="uninvite", description="Revoke a pending invite from your team"
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder", member="Player whose invite to revoke")
+    async def team_uninvite(
+        self, interaction: Interaction, ladder: str, member: Member
+    ):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can revoke invites.")
+                return
+
+            invite: LadderTeamInvite | None = (
+                session.query(LadderTeamInvite)
+                .filter(
+                    LadderTeamInvite.team_id == team.id,
+                    LadderTeamInvite.player_id == member.id,
+                )
+                .first()
+            )
+            if not invite:
+                await _err(
+                    interaction,
+                    f"No pending invite for {escape_markdown(member.name)}.",
+                )
+                return
+            session.delete(invite)
+            session.commit()
+
+            await _ok(
+                interaction,
+                f"Invite for {member.mention} to **{team.name}** revoked.",
+            )
+
+    @team_group.command(name="accept", description="Accept an invite to a team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, team_name=ladder_team_autocomplete
+    )
+    @app_commands.describe(ladder="Ladder", team_name="Team you were invited to")
+    async def team_accept(self, interaction: Interaction, ladder: str, team_name: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+            team = _find_team(session, ladder_row.id, team_name)
+            if not team:
+                await _err(
+                    interaction, f"Team **{team_name}** not found in this ladder."
+                )
+                return
+
+            invite: LadderTeamInvite | None = (
+                session.query(LadderTeamInvite)
+                .filter(
+                    LadderTeamInvite.team_id == team.id,
+                    LadderTeamInvite.player_id == interaction.user.id,
+                )
+                .first()
+            )
+            if not invite:
+                await _err(
+                    interaction,
+                    f"No pending invite to **{team.name}** for you.",
+                )
+                return
+
+            existing = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if existing:
+                await _err(
+                    interaction,
+                    (
+                        f"You are already on team **{existing.name}** in this "
+                        f"ladder. Leave it first with `/ladder team leave`."
+                    ),
+                )
+                return
+
+            roster_size = _team_roster_size(session, team.id)
+            if roster_size >= ladder_row.max_team_size:
+                await _err(
+                    interaction,
+                    f"Team is full (cap {ladder_row.max_team_size}).",
+                )
+                return
+
+            _ensure_player(session, interaction.user)
+            session.add(
+                LadderTeamPlayer(team_id=team.id, player_id=interaction.user.id)
+            )
+            session.delete(invite)
+            session.commit()
+
+            await _ok(
+                interaction,
+                f"You joined **{escape_markdown(team.name)}**.",
+            )
+
+    @team_group.command(name="decline", description="Decline an invite to a team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, team_name=ladder_team_autocomplete
+    )
+    @app_commands.describe(ladder="Ladder", team_name="Team to decline")
+    async def team_decline(self, interaction: Interaction, ladder: str, team_name: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_team(session, ladder_row.id, team_name)
+            if not team:
+                await _err(
+                    interaction, f"Team **{team_name}** not found in this ladder."
+                )
+                return
+            invite: LadderTeamInvite | None = (
+                session.query(LadderTeamInvite)
+                .filter(
+                    LadderTeamInvite.team_id == team.id,
+                    LadderTeamInvite.player_id == interaction.user.id,
+                )
+                .first()
+            )
+            if not invite:
+                await _err(
+                    interaction, f"No pending invite to **{team.name}** for you."
+                )
+                return
+            session.delete(invite)
+            session.commit()
+
+            await _ok(
+                interaction,
+                f"Declined invite to **{escape_markdown(team.name)}**.",
+                ephemeral=True,
+            )
+
+    @team_group.command(name="leave", description="Leave your team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def team_leave(self, interaction: Interaction, ladder: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team:
+                await _err(interaction, "You are not on a team in this ladder.")
+                return
+            if team.captain_id == interaction.user.id:
+                roster_size = _team_roster_size(session, team.id)
+                if roster_size > 1:
+                    await _err(
+                        interaction,
+                        (
+                            "You are the captain. Transfer captaincy with "
+                            "`/ladder team transfer` before leaving, or disband "
+                            "the team with `/ladder team disband`."
+                        ),
+                    )
+                    return
+                # Solo captain leaving: equivalent to disband (after in-flight
+                # check).
+                if _team_has_in_flight_match(session, team.id):
+                    await _err(
+                        interaction,
+                        ("Team has an in-flight match. Resolve it before " "leaving."),
+                    )
+                    return
+                team_name = team.name
+                session.query(LadderTeamInvite).filter(
+                    LadderTeamInvite.team_id == team.id
+                ).delete()
+                session.query(LadderTeamPlayer).filter(
+                    LadderTeamPlayer.team_id == team.id
+                ).delete()
+                self._compact_positions(session, ladder_row.id, team.position)
+                session.delete(team)
+                session.commit()
+                await _ok(
+                    interaction,
+                    f"You left and disbanded **{escape_markdown(team_name)}**.",
+                )
+                return
+
+            session.query(LadderTeamPlayer).filter(
+                LadderTeamPlayer.team_id == team.id,
+                LadderTeamPlayer.player_id == interaction.user.id,
+            ).delete()
+            session.commit()
+
+            await _ok(interaction, f"You left **{escape_markdown(team.name)}**.")
+
+    @team_group.command(name="kick", description="Kick a player from your team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder", member="Player to kick")
+    async def team_kick(self, interaction: Interaction, ladder: str, member: Member):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can kick players.")
+                return
+            if member.id == interaction.user.id:
+                await _err(
+                    interaction,
+                    "You can't kick yourself. Use `/ladder team transfer` "
+                    "or `/ladder team disband`.",
+                )
+                return
+            roster_row: LadderTeamPlayer | None = (
+                session.query(LadderTeamPlayer)
+                .filter(
+                    LadderTeamPlayer.team_id == team.id,
+                    LadderTeamPlayer.player_id == member.id,
+                )
+                .first()
+            )
+            if not roster_row:
+                await _err(
+                    interaction,
+                    f"{escape_markdown(member.name)} is not on this team.",
+                )
+                return
+            session.delete(roster_row)
+            session.commit()
+
+            await _ok(
+                interaction,
+                f"{member.mention} kicked from **{escape_markdown(team.name)}**.",
+            )
+
+    @team_group.command(
+        name="transfer", description="Transfer captaincy to another team member"
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder", member="New captain (must be on the team)")
+    async def team_transfer(
+        self, interaction: Interaction, ladder: str, member: Member
+    ):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can transfer captaincy.")
+                return
+            if member.id == interaction.user.id:
+                await _err(interaction, "You are already the captain.")
+                return
+            on_team: LadderTeamPlayer | None = (
+                session.query(LadderTeamPlayer)
+                .filter(
+                    LadderTeamPlayer.team_id == team.id,
+                    LadderTeamPlayer.player_id == member.id,
+                )
+                .first()
+            )
+            if not on_team:
+                await _err(
+                    interaction,
+                    f"{escape_markdown(member.name)} is not on this team.",
+                )
+                return
+            team.captain_id = member.id
+            session.commit()
+
+            await _ok(
+                interaction,
+                (
+                    f"Captaincy of **{escape_markdown(team.name)}** transferred to "
+                    f"{member.mention}."
+                ),
+            )
+
+    @team_group.command(name="disband", description="Disband your team")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def team_disband(self, interaction: Interaction, ladder: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(interaction, "Only the team captain can disband.")
+                return
+            if _team_has_in_flight_match(session, team.id):
+                await _err(
+                    interaction,
+                    (
+                        "Team has an in-flight match. Cancel or play it first "
+                        "(or ask an admin to resolve it)."
+                    ),
+                )
+                return
+            team_name = team.name
+            session.query(LadderTeamInvite).filter(
+                LadderTeamInvite.team_id == team.id
+            ).delete()
+            session.query(LadderTeamPlayer).filter(
+                LadderTeamPlayer.team_id == team.id
+            ).delete()
+            self._compact_positions(session, ladder_row.id, team.position)
+            session.delete(team)
+            session.commit()
+
+            await _ok(
+                interaction,
+                f"Team **{escape_markdown(team_name)}** disbanded.",
+            )
+
+    @team_group.command(name="info", description="Show a team's roster and record")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, team_name=ladder_team_autocomplete
+    )
+    @app_commands.describe(ladder="Ladder", team_name="Team")
+    async def team_info(self, interaction: Interaction, ladder: str, team_name: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_team(session, ladder_row.id, team_name)
+            if not team:
+                await _err(
+                    interaction, f"Team **{team_name}** not found in this ladder."
+                )
+                return
+
+            roster: list[tuple[Player, LadderTeamPlayer]] = (
+                session.query(Player, LadderTeamPlayer)
+                .join(LadderTeamPlayer, LadderTeamPlayer.player_id == Player.id)
+                .filter(LadderTeamPlayer.team_id == team.id)
+                .order_by(LadderTeamPlayer.joined_at)
+                .all()
+            )
+            captain_mention = f"<@{team.captain_id}>"
+            roster_lines = []
+            for player, _ in roster:
+                marker = " (C)" if player.id == team.captain_id else ""
+                roster_lines.append(f"- <@{player.id}>{marker}")
+            roster_str = "\n".join(roster_lines) if roster_lines else "*(empty)*"
+
+            embed = Embed(
+                title=f"{team.name} — {ladder_row.name}",
+                colour=Colour.blue(),
+            )
+            embed.add_field(name="Position", value=str(team.position), inline=True)
+            embed.add_field(
+                name="Record",
+                value=f"{team.wins}-{team.losses}-{team.draws}",
+                inline=True,
+            )
+            embed.add_field(name="Captain", value=captain_mention, inline=True)
+            embed.add_field(
+                name=f"Roster ({len(roster)}/{ladder_row.max_team_size})",
+                value=roster_str,
+                inline=False,
+            )
+            await interaction.response.send_message(embed=embed)
+
+    @team_group.command(name="list", description="List all teams in a ladder")
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def team_list(self, interaction: Interaction, ladder: str):
+        session: SQLAlchemySession
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            teams: list[LadderTeam] = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.ladder_id == ladder_row.id)
+                .order_by(LadderTeam.position)
+                .all()
+            )
+            if not teams:
+                await _ok(
+                    interaction,
+                    f"Ladder **{ladder}** has no teams yet.",
+                )
+                return
+            lines = []
+            for team in teams:
+                roster_size = _team_roster_size(session, team.id)
+                lines.append(
+                    f"`{team.position:>2}.` **{escape_markdown(team.name)}** "
+                    f"— {team.wins}-{team.losses}-{team.draws} "
+                    f"({roster_size}/{ladder_row.max_team_size})"
+                )
+            embed = Embed(
+                title=f"Teams — {ladder_row.name}",
+                description="\n".join(lines),
+                colour=Colour.blue(),
+            )
+            await interaction.response.send_message(embed=embed)
+
+    def _compact_positions(
+        self,
+        session: SQLAlchemySession,
+        ladder_id: str,
+        removed_position: int,
+    ) -> None:
+        """Shift teams below `removed_position` up by one to close the gap."""
+        below = (
+            session.query(LadderTeam)
+            .filter(
+                LadderTeam.ladder_id == ladder_id,
+                LadderTeam.position > removed_position,
+            )
+            .order_by(LadderTeam.position)
+            .all()
+        )
+        for team in below:
+            team.position -= 1

--- a/discord_bots/cogs/ladder.py
+++ b/discord_bots/cogs/ladder.py
@@ -2,8 +2,18 @@ import logging
 import random
 from datetime import datetime, timezone
 
-from discord import Colour, Embed, Interaction, Member, TextChannel, app_commands
+import discord
+from discord import (
+    Colour,
+    Embed,
+    Interaction,
+    Member,
+    TextChannel,
+    TextStyle,
+    app_commands,
+)
 from discord.ext.commands import Bot
+from discord.ui import Modal, TextInput
 from discord.utils import escape_markdown
 from sqlalchemy import func
 from sqlalchemy.exc import IntegrityError
@@ -27,6 +37,7 @@ from discord_bots.models import (
 )
 from discord_bots.utils import (
     ladder_autocomplete,
+    ladder_match_autocomplete,
     ladder_team_autocomplete,
     rotation_autocomplete,
 )
@@ -271,6 +282,389 @@ async def _ok(interaction: Interaction, msg: str, ephemeral: bool = False) -> No
         await interaction.response.send_message(embed=embed, ephemeral=ephemeral)
     else:
         await interaction.followup.send(embed=embed, ephemeral=ephemeral)
+
+
+def _apply_position_swap(
+    session: SQLAlchemySession,
+    ladder_id: str,
+    challenger: LadderTeam,
+    defender: LadderTeam,
+) -> tuple[int, int]:
+    """
+    Move challenger immediately above defender. Defender drops by 1; teams
+    between also drop by 1. Returns (old_challenger_pos, old_defender_pos).
+
+    Caller must guarantee defender.position < challenger.position.
+    """
+    old_defender = defender.position
+    old_challenger = challenger.position
+
+    # Park challenger at a safe negative position to avoid the (ladder_id,
+    # position) unique constraint while we shift the middle teams down.
+    challenger.position = -1
+    session.flush()
+
+    middle = (
+        session.query(LadderTeam)
+        .filter(
+            LadderTeam.ladder_id == ladder_id,
+            LadderTeam.position >= old_defender,
+            LadderTeam.position < old_challenger,
+        )
+        .order_by(LadderTeam.position.desc())
+        .all()
+    )
+    for t in middle:
+        t.position = t.position + 1
+        session.flush()
+
+    challenger.position = old_defender
+    session.flush()
+    return old_challenger, old_defender
+
+
+def _compute_match_winner_team_id(
+    session: SQLAlchemySession, match: LadderMatch
+) -> tuple[str | None, int, int]:
+    """
+    Tally map wins from LadderMatchGame rows. Returns
+    (winner_team_id_or_none_for_draw, challenger_map_wins, defender_map_wins).
+    """
+    games: list[LadderMatchGame] = (
+        session.query(LadderMatchGame)
+        .filter(LadderMatchGame.match_id == match.id)
+        .all()
+    )
+    challenger_wins = sum(1 for g in games if g.winner_team == 0)
+    defender_wins = sum(1 for g in games if g.winner_team == 1)
+    if challenger_wins > defender_wins:
+        return match.challenger_team_id, challenger_wins, defender_wins
+    if defender_wins > challenger_wins:
+        return match.defender_team_id, challenger_wins, defender_wins
+    return None, challenger_wins, defender_wins
+
+
+def _undo_records_and_position(
+    session: SQLAlchemySession,
+    ladder_id: str,
+    match: LadderMatch,
+) -> None:
+    """
+    Reverse a previously-applied finalization. Used by admin editmatch when a
+    completed match is re-resolved with a different outcome.
+    """
+    challenger = (
+        session.query(LadderTeam)
+        .filter(LadderTeam.id == match.challenger_team_id)
+        .first()
+    )
+    defender = (
+        session.query(LadderTeam)
+        .filter(LadderTeam.id == match.defender_team_id)
+        .first()
+    )
+    if not challenger or not defender:
+        return
+    if match.winner_team_id == match.challenger_team_id:
+        challenger.wins = max(0, challenger.wins - 1)
+        defender.losses = max(0, defender.losses - 1)
+    elif match.winner_team_id == match.defender_team_id:
+        defender.wins = max(0, defender.wins - 1)
+        challenger.losses = max(0, challenger.losses - 1)
+    else:
+        challenger.draws = max(0, challenger.draws - 1)
+        defender.draws = max(0, defender.draws - 1)
+    session.flush()
+
+    # Reverse position swap if challenger had won and current positions reflect
+    # the swap.
+    if match.winner_team_id == match.challenger_team_id:
+        old_challenger_pos = match.challenger_position_at_challenge
+        old_defender_pos = match.defender_position_at_challenge
+        if (
+            old_defender_pos < old_challenger_pos
+            and challenger.position == old_defender_pos
+            and defender.position == old_defender_pos + 1
+        ):
+            # Park challenger, shift middle teams up by 1, restore challenger.
+            challenger.position = -1
+            session.flush()
+            middle = (
+                session.query(LadderTeam)
+                .filter(
+                    LadderTeam.ladder_id == ladder_id,
+                    LadderTeam.position > old_defender_pos,
+                    LadderTeam.position <= old_challenger_pos,
+                )
+                .order_by(LadderTeam.position)
+                .all()
+            )
+            for t in middle:
+                t.position = t.position - 1
+                session.flush()
+            challenger.position = old_challenger_pos
+            session.flush()
+
+
+def _finalize_match_outcome(
+    session: SQLAlchemySession,
+    ladder: Ladder,
+    match: LadderMatch,
+    forced_winner_team_id: str | None,
+    is_draw: bool,
+    challenger_map_wins: int,
+    defender_map_wins: int,
+) -> tuple[LadderTeam, LadderTeam, str, str | None]:
+    """
+    Apply records + position rule for a finalized match. Caller must have
+    already updated LadderMatchGame rows (or be force-ending without per-game
+    detail). Returns (challenger, defender, winner_label, winner_team_id).
+    """
+    challenger = (
+        session.query(LadderTeam)
+        .filter(LadderTeam.id == match.challenger_team_id)
+        .first()
+    )
+    defender = (
+        session.query(LadderTeam)
+        .filter(LadderTeam.id == match.defender_team_id)
+        .first()
+    )
+    if not challenger or not defender:
+        raise RuntimeError("Match references missing team rows")
+
+    winner_team_id: str | None
+    if is_draw:
+        winner_team_id = None
+    else:
+        winner_team_id = forced_winner_team_id
+
+    match.challenger_map_wins = challenger_map_wins
+    match.defender_map_wins = defender_map_wins
+    match.status = "completed"
+    match.completed_at = _utc_now_naive()
+    match.winner_team_id = winner_team_id
+
+    if winner_team_id == challenger.id:
+        challenger.wins += 1
+        defender.losses += 1
+        winner_label = challenger.name
+    elif winner_team_id == defender.id:
+        defender.wins += 1
+        challenger.losses += 1
+        winner_label = defender.name
+    else:
+        challenger.draws += 1
+        defender.draws += 1
+        winner_label = "draw"
+
+    if winner_team_id == challenger.id and defender.position < challenger.position:
+        _apply_position_swap(session, ladder.id, challenger, defender)
+
+    session.flush()
+    return challenger, defender, winner_label, winner_team_id
+
+
+class _ReportMatchModal(Modal):
+    def __init__(
+        self,
+        *,
+        match_id: str,
+        ladder_id: str,
+        ladder_name: str,
+        challenger_name: str,
+        defender_name: str,
+        is_admin_edit: bool,
+    ):
+        title = f"Report: {challenger_name} vs {defender_name}"
+        super().__init__(title=title[:45], timeout=None)
+        self.match_id = match_id
+        self.ladder_id = ladder_id
+        self.is_admin_edit = is_admin_edit
+        self._inputs: list[TextInput] = []
+
+        with Session() as session:
+            games: list[tuple[LadderMatchGame, Map]] = (
+                session.query(LadderMatchGame, Map)
+                .join(Map, Map.id == LadderMatchGame.map_id)
+                .filter(LadderMatchGame.match_id == match_id)
+                .order_by(LadderMatchGame.ordinal)
+                .all()
+            )
+            for game, m in games:
+                current = ""
+                if (
+                    game.challenger_score is not None
+                    and game.defender_score is not None
+                ):
+                    current = f"{game.challenger_score}-{game.defender_score}"
+                label = f"Map {game.ordinal}: {m.full_name}"
+                ti = TextInput(
+                    label=label[:45],
+                    style=TextStyle.short,
+                    placeholder="our-their, e.g. 3-1 (or 3-3 for draw)",
+                    default=current,
+                    required=True,
+                    max_length=20,
+                )
+                self.add_item(ti)
+                self._inputs.append(ti)
+
+    @staticmethod
+    def _parse_score(raw: str) -> tuple[int, int] | None:
+        s = raw.strip()
+        if "-" not in s:
+            return None
+        a, _, b = s.partition("-")
+        try:
+            ai = int(a.strip())
+            bi = int(b.strip())
+        except ValueError:
+            return None
+        if ai < 0 or bi < 0:
+            return None
+        return ai, bi
+
+    async def on_submit(self, interaction: Interaction) -> None:
+        await interaction.response.defer()
+
+        parsed: list[tuple[int, int]] = []
+        for ti in self._inputs:
+            r = self._parse_score(ti.value or "")
+            if r is None:
+                await interaction.followup.send(
+                    embed=Embed(
+                        description=(
+                            f"Invalid score in `{ti.label}`: "
+                            f"`{ti.value}`. Use `our-their`, e.g. `3-1`."
+                        ),
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            parsed.append(r)
+
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+
+        with Session() as session:
+            match: LadderMatch | None = (
+                session.query(LadderMatch)
+                .filter(LadderMatch.id == self.match_id)
+                .first()
+            )
+            if not match:
+                await interaction.followup.send(
+                    embed=Embed(
+                        description="Match disappeared. Aborting.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+            ladder = session.query(Ladder).filter(Ladder.id == match.ladder_id).first()
+            if not ladder:
+                return
+
+            if self.is_admin_edit and match.status == "completed":
+                _undo_records_and_position(session, ladder.id, match)
+                match.status = "accepted"
+                session.flush()
+
+            games: list[LadderMatchGame] = (
+                session.query(LadderMatchGame)
+                .filter(LadderMatchGame.match_id == match.id)
+                .order_by(LadderMatchGame.ordinal)
+                .all()
+            )
+            if len(games) != len(parsed):
+                await interaction.followup.send(
+                    embed=Embed(
+                        description="Map count mismatch. Re-run the command.",
+                        colour=Colour.red(),
+                    ),
+                    ephemeral=True,
+                )
+                return
+
+            now = _utc_now_naive()
+            for game, (cs, ds) in zip(games, parsed):
+                game.challenger_score = cs
+                game.defender_score = ds
+                if cs > ds:
+                    game.winner_team = 0
+                elif ds > cs:
+                    game.winner_team = 1
+                else:
+                    game.winner_team = -1
+                game.reported_at = now
+                game.reported_by_id = interaction.user.id
+            session.flush()
+
+            winner_team_id, c_wins, d_wins = _compute_match_winner_team_id(
+                session, match
+            )
+            challenger, defender, winner_label, _ = _finalize_match_outcome(
+                session,
+                ladder,
+                match,
+                forced_winner_team_id=winner_team_id,
+                is_draw=winner_team_id is None,
+                challenger_map_wins=c_wins,
+                defender_map_wins=d_wins,
+            )
+            session.commit()
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder.id).first()
+            )
+
+            score_lines = []
+            for g, (cs, ds) in zip(games, parsed):
+                tag = ""
+                if g.winner_team == 0:
+                    tag = " (challenger)"
+                elif g.winner_team == 1:
+                    tag = " (defender)"
+                score_lines.append(f"Map {g.ordinal}: {cs}-{ds}{tag}")
+
+            if winner_label == "draw":
+                outcome = "Draw — no position change."
+            elif winner_team_id == challenger.id:
+                outcome = (
+                    f"**{escape_markdown(challenger.name)}** wins and moves "
+                    f"to position **{challenger.position}**. "
+                    f"**{escape_markdown(defender.name)}** drops to "
+                    f"**{defender.position}**."
+                )
+            else:
+                outcome = (
+                    f"**{escape_markdown(defender.name)}** holds. "
+                    f"No position change."
+                )
+
+            history_embed = Embed(
+                title="Match completed",
+                description=(
+                    f"**{escape_markdown(challenger.name)}** vs "
+                    f"**{escape_markdown(defender.name)}** — "
+                    f"{c_wins}-{d_wins}\n\n" + "\n".join(score_lines) + f"\n\n{outcome}"
+                ),
+                colour=Colour.green(),
+            )
+            if self.is_admin_edit:
+                history_embed.title = "Match edited (admin)"
+
+            await interaction.followup.send(
+                embed=Embed(
+                    description=(f"Match recorded. {outcome}"),
+                    colour=Colour.green(),
+                )
+            )
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
 
 
 class LadderCommands(BaseCog):
@@ -1613,6 +2007,589 @@ class LadderCommands(BaseCog):
                 colour=Colour.dark_grey(),
             )
             await _ok(interaction, "Challenge cancelled.")
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    # ------------------------------------------------------------------
+    # Reporting + match info
+    # ------------------------------------------------------------------
+
+    @ladder_group.command(
+        name="report",
+        description="Report scores for your accepted match",
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def report(self, interaction: Interaction, ladder: str):
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            if not ladder_row.is_active:
+                await _err(interaction, f"Ladder **{ladder}** is inactive.")
+                return
+            team = _find_player_team_in_ladder(
+                session, ladder_row.id, interaction.user.id
+            )
+            if not team or team.captain_id != interaction.user.id:
+                await _err(
+                    interaction,
+                    "Only the team captain can report scores.",
+                )
+                return
+            match: LadderMatch | None = (
+                session.query(LadderMatch)
+                .filter(
+                    LadderMatch.status == "accepted",
+                    (LadderMatch.challenger_team_id == team.id)
+                    | (LadderMatch.defender_team_id == team.id),
+                )
+                .first()
+            )
+            if not match:
+                await _err(
+                    interaction,
+                    "Your team has no accepted match to report.",
+                )
+                return
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            defender = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            if not challenger or not defender:
+                await _err(interaction, "Match references missing teams.")
+                return
+
+            modal = _ReportMatchModal(
+                match_id=match.id,
+                ladder_id=ladder_row.id,
+                ladder_name=ladder_row.name,
+                challenger_name=challenger.name,
+                defender_name=defender.name,
+                is_admin_edit=False,
+            )
+
+        await interaction.response.send_modal(modal)
+
+    @ladder_group.command(
+        name="matchinfo",
+        description="Show details for a match",
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(match_id=ladder_match_autocomplete)
+    @app_commands.describe(match_id="Match")
+    async def match_info(self, interaction: Interaction, match_id: str):
+        with Session() as session:
+            match = (
+                session.query(LadderMatch).filter(LadderMatch.id == match_id).first()
+            )
+            if not match:
+                await _err(interaction, "Match not found.")
+                return
+            ladder = session.query(Ladder).filter(Ladder.id == match.ladder_id).first()
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            defender = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            games: list[tuple[LadderMatchGame, Map]] = (
+                session.query(LadderMatchGame, Map)
+                .join(Map, Map.id == LadderMatchGame.map_id)
+                .filter(LadderMatchGame.match_id == match.id)
+                .order_by(LadderMatchGame.ordinal)
+                .all()
+            )
+
+            game_lines = []
+            for g, m in games:
+                if g.challenger_score is None or g.defender_score is None:
+                    game_lines.append(
+                        f"Map {g.ordinal} ({escape_markdown(m.full_name)}): "
+                        f"*not reported*"
+                    )
+                else:
+                    tag = ""
+                    if g.winner_team == 0:
+                        tag = " (challenger)"
+                    elif g.winner_team == 1:
+                        tag = " (defender)"
+                    elif g.winner_team == -1:
+                        tag = " (draw)"
+                    game_lines.append(
+                        f"Map {g.ordinal} ({escape_markdown(m.full_name)}): "
+                        f"{g.challenger_score}-{g.defender_score}{tag}"
+                    )
+
+            embed = Embed(
+                title=(
+                    f"{ladder.name if ladder else '?'}: "
+                    f"{challenger.name if challenger else '?'} vs "
+                    f"{defender.name if defender else '?'}"
+                ),
+                colour=Colour.blue(),
+            )
+            embed.add_field(name="Status", value=match.status, inline=True)
+            embed.add_field(
+                name="Score",
+                value=(f"{match.challenger_map_wins}-{match.defender_map_wins}"),
+                inline=True,
+            )
+            if match.winner_team_id:
+                winner = (
+                    session.query(LadderTeam)
+                    .filter(LadderTeam.id == match.winner_team_id)
+                    .first()
+                )
+                if winner:
+                    embed.add_field(name="Winner", value=winner.name, inline=True)
+            embed.add_field(
+                name="Games",
+                value="\n".join(game_lines) if game_lines else "*(none)*",
+                inline=False,
+            )
+            embed.add_field(name="Match ID", value=f"`{match.id}`", inline=False)
+            await interaction.response.send_message(embed=embed)
+
+    @ladder_group.command(
+        name="rankings", description="Show the current ladder rankings"
+    )
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(ladder=ladder_autocomplete)
+    @app_commands.describe(ladder="Ladder")
+    async def rankings(self, interaction: Interaction, ladder: str):
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            embed = _build_leaderboard_embed(session, ladder_row)
+        await interaction.response.send_message(embed=embed)
+
+    # ------------------------------------------------------------------
+    # Admin: editmatch / forceendmatch / cancelmatch / forceadjust /
+    # removeteam
+    # ------------------------------------------------------------------
+
+    @admin_group.command(
+        name="editmatch",
+        description="Open the report modal for a match (admin)",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(match_id=ladder_match_autocomplete)
+    @app_commands.describe(match_id="Match to edit")
+    async def admin_editmatch(self, interaction: Interaction, match_id: str):
+        with Session() as session:
+            match = (
+                session.query(LadderMatch).filter(LadderMatch.id == match_id).first()
+            )
+            if not match:
+                await _err(interaction, "Match not found.")
+                return
+            if match.status not in ("accepted", "completed"):
+                await _err(
+                    interaction,
+                    f"Match status is `{match.status}`; nothing to edit.",
+                )
+                return
+            ladder = session.query(Ladder).filter(Ladder.id == match.ladder_id).first()
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            defender = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            if not ladder or not challenger or not defender:
+                await _err(interaction, "Match references missing rows.")
+                return
+
+            modal = _ReportMatchModal(
+                match_id=match.id,
+                ladder_id=ladder.id,
+                ladder_name=ladder.name,
+                challenger_name=challenger.name,
+                defender_name=defender.name,
+                is_admin_edit=True,
+            )
+
+        await interaction.response.send_modal(modal)
+
+    @admin_group.command(
+        name="forceendmatch",
+        description="Force-end an accepted match in a team's favor",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(match_id=ladder_match_autocomplete)
+    @app_commands.choices(
+        winner=[
+            app_commands.Choice(name="challenger", value="challenger"),
+            app_commands.Choice(name="defender", value="defender"),
+            app_commands.Choice(name="draw", value="draw"),
+        ]
+    )
+    @app_commands.describe(match_id="Match", winner="Outcome")
+    async def admin_forceendmatch(
+        self,
+        interaction: Interaction,
+        match_id: str,
+        winner: str,
+    ):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+
+        with Session() as session:
+            match = (
+                session.query(LadderMatch).filter(LadderMatch.id == match_id).first()
+            )
+            if not match:
+                await _err(interaction, "Match not found.")
+                return
+            if match.status not in ("pending", "accepted"):
+                await _err(
+                    interaction,
+                    f"Match is `{match.status}`; force-end only applies to "
+                    f"in-flight matches.",
+                )
+                return
+            ladder = session.query(Ladder).filter(Ladder.id == match.ladder_id).first()
+            if not ladder:
+                return
+
+            if winner == "challenger":
+                forced = match.challenger_team_id
+                is_draw = False
+                c_wins = ladder.maps_per_match
+                d_wins = 0
+            elif winner == "defender":
+                forced = match.defender_team_id
+                is_draw = False
+                c_wins = 0
+                d_wins = ladder.maps_per_match
+            else:
+                forced = None
+                is_draw = True
+                c_wins = 0
+                d_wins = 0
+
+            challenger, defender, winner_label, _ = _finalize_match_outcome(
+                session,
+                ladder,
+                match,
+                forced_winner_team_id=forced,
+                is_draw=is_draw,
+                challenger_map_wins=c_wins,
+                defender_map_wins=d_wins,
+            )
+            session.commit()
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder.id).first()
+            )
+
+            if winner_label == "draw":
+                outcome = "Draw — no position change."
+            elif winner == "challenger":
+                outcome = (
+                    f"**{escape_markdown(challenger.name)}** moves to "
+                    f"position **{challenger.position}**; "
+                    f"**{escape_markdown(defender.name)}** drops to "
+                    f"**{defender.position}**."
+                )
+            else:
+                outcome = (
+                    f"**{escape_markdown(defender.name)}** holds. "
+                    f"No position change."
+                )
+
+            history_embed = Embed(
+                title="Match force-ended (admin)",
+                description=(
+                    f"**{escape_markdown(challenger.name)}** vs "
+                    f"**{escape_markdown(defender.name)}** — "
+                    f"resolved by <@{interaction.user.id}> as "
+                    f"**{winner}**.\n\n{outcome}"
+                ),
+                colour=Colour.dark_green(),
+            )
+            await _ok(
+                interaction,
+                f"Match force-ended as **{winner}**. {outcome}",
+            )
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @admin_group.command(
+        name="cancelmatch",
+        description="Void a match without recording a result",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(match_id=ladder_match_autocomplete)
+    @app_commands.describe(match_id="Match to cancel")
+    async def admin_cancelmatch(self, interaction: Interaction, match_id: str):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+
+        with Session() as session:
+            match = (
+                session.query(LadderMatch).filter(LadderMatch.id == match_id).first()
+            )
+            if not match:
+                await _err(interaction, "Match not found.")
+                return
+            ladder = session.query(Ladder).filter(Ladder.id == match.ladder_id).first()
+            if not ladder:
+                return
+
+            if match.status == "completed":
+                _undo_records_and_position(session, ladder.id, match)
+
+            match.status = "cancelled"
+            match.completed_at = _utc_now_naive()
+            match.winner_team_id = None
+            match.challenger_map_wins = 0
+            match.defender_map_wins = 0
+            session.flush()
+
+            challenger = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            defender = (
+                session.query(LadderTeam)
+                .filter(LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            session.commit()
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder.id).first()
+            )
+
+            history_embed = Embed(
+                title="Match cancelled (admin)",
+                description=(
+                    f"<@{interaction.user.id}> cancelled the match between "
+                    f"**{escape_markdown(challenger.name) if challenger else '?'}** and "
+                    f"**{escape_markdown(defender.name) if defender else '?'}** "
+                    f"on ladder **{ladder.name}**."
+                ),
+                colour=Colour.dark_grey(),
+            )
+            await _ok(interaction, "Match cancelled.")
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @admin_group.command(
+        name="forceadjust",
+        description="Manually move a team to a new position",
+    )
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, team_name=ladder_team_autocomplete
+    )
+    @app_commands.describe(
+        ladder="Ladder",
+        team_name="Team to move",
+        new_position="Target position (1 = top)",
+    )
+    async def admin_forceadjust(
+        self,
+        interaction: Interaction,
+        ladder: str,
+        team_name: str,
+        new_position: int,
+    ):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_team(session, ladder_row.id, team_name)
+            if not team:
+                await _err(
+                    interaction,
+                    f"Team **{team_name}** not found in this ladder.",
+                )
+                return
+
+            total_teams = (
+                session.query(func.count(LadderTeam.id))
+                .filter(LadderTeam.ladder_id == ladder_row.id)
+                .scalar()
+                or 0
+            )
+            if new_position < 1 or new_position > total_teams:
+                await _err(
+                    interaction,
+                    f"Position must be between 1 and {total_teams}.",
+                )
+                return
+            old_position = team.position
+            if old_position == new_position:
+                await _ok(interaction, "Team is already at that position.")
+                return
+
+            # Park team at -1 and shift others to fill / make room.
+            team.position = -1
+            session.flush()
+
+            if new_position < old_position:
+                # Moving up: teams in [new_position, old_position) shift down by 1.
+                middle = (
+                    session.query(LadderTeam)
+                    .filter(
+                        LadderTeam.ladder_id == ladder_row.id,
+                        LadderTeam.position >= new_position,
+                        LadderTeam.position < old_position,
+                    )
+                    .order_by(LadderTeam.position.desc())
+                    .all()
+                )
+                for t in middle:
+                    t.position = t.position + 1
+                    session.flush()
+            else:
+                # Moving down: teams in (old_position, new_position] shift up by 1.
+                middle = (
+                    session.query(LadderTeam)
+                    .filter(
+                        LadderTeam.ladder_id == ladder_row.id,
+                        LadderTeam.position > old_position,
+                        LadderTeam.position <= new_position,
+                    )
+                    .order_by(LadderTeam.position)
+                    .all()
+                )
+                for t in middle:
+                    t.position = t.position - 1
+                    session.flush()
+
+            team.position = new_position
+            session.commit()
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            history_embed = Embed(
+                title="Position adjusted (admin)",
+                description=(
+                    f"<@{interaction.user.id}> moved "
+                    f"**{escape_markdown(team.name)}** from position "
+                    f"**{old_position}** to **{new_position}** on ladder "
+                    f"**{ladder_row.name}**."
+                ),
+                colour=Colour.dark_blue(),
+            )
+            await _ok(
+                interaction,
+                f"Moved **{escape_markdown(team.name)}** to position "
+                f"**{new_position}**.",
+            )
+
+        if history_embed and ladder_snapshot:
+            await _post_history(ladder_snapshot, history_embed)
+            await _refresh_leaderboard(ladder_snapshot)
+
+    @admin_group.command(name="removeteam", description="Force-disband a team (admin)")
+    @app_commands.check(is_admin_app_command)
+    @app_commands.check(is_ladder_channel)
+    @app_commands.autocomplete(
+        ladder=ladder_autocomplete, team_name=ladder_team_autocomplete
+    )
+    @app_commands.describe(ladder="Ladder", team_name="Team to remove")
+    async def admin_removeteam(
+        self, interaction: Interaction, ladder: str, team_name: str
+    ):
+        await interaction.response.defer()
+        ladder_snapshot: Ladder | None = None
+        history_embed: Embed | None = None
+
+        with Session() as session:
+            ladder_row = _find_ladder(session, ladder)
+            if not ladder_row:
+                await _err(interaction, f"Ladder **{ladder}** not found.")
+                return
+            team = _find_team(session, ladder_row.id, team_name)
+            if not team:
+                await _err(
+                    interaction,
+                    f"Team **{team_name}** not found in this ladder.",
+                )
+                return
+
+            # Cancel any in-flight matches referencing this team.
+            in_flight: list[LadderMatch] = (
+                session.query(LadderMatch)
+                .filter(
+                    LadderMatch.status.in_(IN_FLIGHT_STATUSES),
+                    (LadderMatch.challenger_team_id == team.id)
+                    | (LadderMatch.defender_team_id == team.id),
+                )
+                .all()
+            )
+            for m in in_flight:
+                m.status = "cancelled"
+                m.completed_at = _utc_now_naive()
+            session.flush()
+
+            removed_position = team.position
+            session.query(LadderTeamInvite).filter(
+                LadderTeamInvite.team_id == team.id
+            ).delete()
+            session.query(LadderTeamPlayer).filter(
+                LadderTeamPlayer.team_id == team.id
+            ).delete()
+            self._compact_positions(session, ladder_row.id, removed_position)
+            session.delete(team)
+            session.commit()
+            ladder_snapshot = (
+                session.query(Ladder).filter(Ladder.id == ladder_row.id).first()
+            )
+
+            history_embed = Embed(
+                title="Team removed (admin)",
+                description=(
+                    f"<@{interaction.user.id}> removed team "
+                    f"**{escape_markdown(team_name)}** from ladder "
+                    f"**{ladder_row.name}**."
+                ),
+                colour=Colour.dark_red(),
+            )
+            await _ok(
+                interaction,
+                f"Team **{escape_markdown(team_name)}** removed.",
+            )
 
         if history_embed and ladder_snapshot:
             await _post_history(ladder_snapshot, history_embed)

--- a/discord_bots/main.py
+++ b/discord_bots/main.py
@@ -24,6 +24,7 @@ from discord_bots.cogs.config import ConfigCommands
 from discord_bots.cogs.draft import DraftCommands
 from discord_bots.cogs.economy import EconomyCommands
 from discord_bots.cogs.in_progress_game import InProgressGameCommands
+from discord_bots.cogs.ladder import LadderCommands
 from discord_bots.cogs.list import ListCommands
 from discord_bots.cogs.map import MapCommands
 from discord_bots.cogs.notification import NotificationCommands
@@ -330,6 +331,7 @@ async def setup():
     await bot.add_cog(NotificationCommands(bot))
     await bot.add_cog(ConfigCommands(bot))
     await bot.add_cog(DraftCommands(bot))
+    await bot.add_cog(LadderCommands(bot))
     add_player_task.start()
     afk_timer_task.start()
     leaderboard_task.start()

--- a/discord_bots/models.py
+++ b/discord_bots/models.py
@@ -238,6 +238,10 @@ class Config:
         default=None,
         metadata={"sa": Column(BigInteger, nullable=True)},
     )
+    ladder_channel_id: int | None = field(
+        default=None,
+        metadata={"sa": Column(BigInteger, nullable=True)},
+    )
     updated_at: datetime = field(
         default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
         init=False,
@@ -1788,6 +1792,317 @@ class VotePassedWaitlistPlayer:
         metadata={"sa": Column(BigInteger, ForeignKey("player.id"), nullable=False)},
     )
     queue_id: str = field(metadata={"sa": Column(String, ForeignKey("queue.id"))})
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class Ladder:
+    """
+    A challenge ladder. Teams in a ladder challenge each other; the winning
+    challenger moves above the defeated team in the rankings.
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder"
+
+    name: str = field(
+        metadata={"sa": Column(String, nullable=False, unique=True)},
+    )
+    rotation_id: str = field(
+        metadata={"sa": Column(String, ForeignKey("rotation.id"), nullable=False)},
+    )
+    maps_per_match: int = field(
+        default=3,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("3"))},
+    )
+    max_team_size: int = field(
+        default=5,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("5"))},
+    )
+    max_challenge_distance: int = field(
+        default=3,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("3"))},
+    )
+    max_in_flight_per_team: int = field(
+        default=1,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("1"))},
+    )
+    leaderboard_channel_id: int | None = field(
+        default=None,
+        metadata={"sa": Column(BigInteger, nullable=True)},
+    )
+    leaderboard_message_id: int | None = field(
+        default=None,
+        metadata={"sa": Column(BigInteger, nullable=True)},
+    )
+    history_channel_id: int | None = field(
+        default=None,
+        metadata={"sa": Column(BigInteger, nullable=True)},
+    )
+    is_active: bool = field(
+        default=True,
+        metadata={
+            "sa": Column(Boolean, nullable=False, server_default=expression.true())
+        },
+    )
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        init=False,
+        metadata={"sa": Column(DateTime, index=True)},
+    )
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class LadderTeam:
+    """
+    A team in a ladder. `position` is 1-indexed from the top of the ladder
+    and is unique within a ladder.
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder_team"
+    __table_args__ = (
+        UniqueConstraint("ladder_id", "name"),
+        UniqueConstraint("ladder_id", "position"),
+    )
+
+    ladder_id: str = field(
+        metadata={
+            "sa": Column(String, ForeignKey("ladder.id"), index=True, nullable=False)
+        }
+    )
+    name: str = field(metadata={"sa": Column(String, nullable=False)})
+    captain_id: int = field(
+        metadata={"sa": Column(BigInteger, ForeignKey("player.id"), nullable=False)}
+    )
+    position: int = field(metadata={"sa": Column(Integer, nullable=False)})
+    wins: int = field(
+        default=0,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("0"))},
+    )
+    losses: int = field(
+        default=0,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("0"))},
+    )
+    draws: int = field(
+        default=0,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("0"))},
+    )
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        init=False,
+        metadata={"sa": Column(DateTime, index=True)},
+    )
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class LadderTeamPlayer:
+    """
+    Roster row for a ladder team.
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder_team_player"
+    __table_args__ = (UniqueConstraint("team_id", "player_id"),)
+
+    team_id: str = field(
+        metadata={
+            "sa": Column(
+                String, ForeignKey("ladder_team.id"), index=True, nullable=False
+            )
+        }
+    )
+    player_id: int = field(
+        metadata={
+            "sa": Column(
+                BigInteger, ForeignKey("player.id"), index=True, nullable=False
+            )
+        }
+    )
+    joined_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        init=False,
+        metadata={"sa": Column(DateTime, index=True)},
+    )
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class LadderTeamInvite:
+    """
+    A captain-issued invite to a player to join a ladder team. Lives until
+    accepted, declined, or revoked.
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder_team_invite"
+    __table_args__ = (UniqueConstraint("team_id", "player_id"),)
+
+    team_id: str = field(
+        metadata={
+            "sa": Column(
+                String, ForeignKey("ladder_team.id"), index=True, nullable=False
+            )
+        }
+    )
+    player_id: int = field(
+        metadata={
+            "sa": Column(
+                BigInteger, ForeignKey("player.id"), index=True, nullable=False
+            )
+        }
+    )
+    invited_by_id: int = field(
+        metadata={"sa": Column(BigInteger, ForeignKey("player.id"), nullable=False)}
+    )
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        init=False,
+        metadata={"sa": Column(DateTime, index=True)},
+    )
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class LadderMatch:
+    """
+    A challenge between two ladder teams. Lifecycle:
+    pending -> accepted -> completed (or cancelled at any point).
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder_match"
+
+    ladder_id: str = field(
+        metadata={
+            "sa": Column(String, ForeignKey("ladder.id"), index=True, nullable=False)
+        }
+    )
+    challenger_team_id: str = field(
+        metadata={
+            "sa": Column(
+                String, ForeignKey("ladder_team.id"), index=True, nullable=False
+            )
+        }
+    )
+    defender_team_id: str = field(
+        metadata={
+            "sa": Column(
+                String, ForeignKey("ladder_team.id"), index=True, nullable=False
+            )
+        }
+    )
+    challenger_position_at_challenge: int = field(
+        metadata={"sa": Column(Integer, nullable=False)}
+    )
+    defender_position_at_challenge: int = field(
+        metadata={"sa": Column(Integer, nullable=False)}
+    )
+    status: str = field(
+        default="pending",
+        metadata={
+            "sa": Column(
+                String, nullable=False, index=True, server_default=text("'pending'")
+            )
+        },
+    )
+    winner_team_id: str | None = field(
+        default=None,
+        metadata={"sa": Column(String, ForeignKey("ladder_team.id"), nullable=True)},
+    )
+    challenger_map_wins: int = field(
+        default=0,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("0"))},
+    )
+    defender_map_wins: int = field(
+        default=0,
+        metadata={"sa": Column(Integer, nullable=False, server_default=text("0"))},
+    )
+    challenged_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        init=False,
+        metadata={"sa": Column(DateTime, index=True)},
+    )
+    accepted_at: datetime | None = field(
+        default=None, metadata={"sa": Column(DateTime, nullable=True)}
+    )
+    completed_at: datetime | None = field(
+        default=None, metadata={"sa": Column(DateTime, nullable=True)}
+    )
+    id: str = field(
+        init=False,
+        default_factory=lambda: str(uuid4()),
+        metadata={"sa": Column(String, primary_key=True)},
+    )
+
+
+@mapper_registry.mapped
+@dataclass
+class LadderMatchGame:
+    """
+    One map within a ladder match. Created at accept-time with a randomly
+    selected map from the ladder's rotation. Scores are filled in when a
+    captain reports the match.
+    """
+
+    __sa_dataclass_metadata_key__ = "sa"
+    __tablename__ = "ladder_match_game"
+    __table_args__ = (UniqueConstraint("match_id", "ordinal"),)
+
+    match_id: str = field(
+        metadata={
+            "sa": Column(
+                String, ForeignKey("ladder_match.id"), index=True, nullable=False
+            )
+        }
+    )
+    ordinal: int = field(metadata={"sa": Column(Integer, nullable=False)})
+    map_id: str = field(
+        metadata={"sa": Column(String, ForeignKey("map.id"), nullable=False)}
+    )
+    challenger_score: int | None = field(
+        default=None, metadata={"sa": Column(Integer, nullable=True)}
+    )
+    defender_score: int | None = field(
+        default=None, metadata={"sa": Column(Integer, nullable=True)}
+    )
+    winner_team: int | None = field(
+        default=None, metadata={"sa": Column(Integer, nullable=True)}
+    )
+    reported_at: datetime | None = field(
+        default=None, metadata={"sa": Column(DateTime, nullable=True)}
+    )
+    reported_by_id: int | None = field(
+        default=None,
+        metadata={"sa": Column(BigInteger, ForeignKey("player.id"), nullable=True)},
+    )
     id: str = field(
         init=False,
         default_factory=lambda: str(uuid4()),

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -1991,6 +1991,50 @@ async def ladder_autocomplete(interaction: Interaction, current: str):
     return result
 
 
+async def ladder_match_autocomplete(interaction: Interaction, current: str):
+    """
+    Autocomplete recent matches across all ladders, labeled with
+    "<ladder>: challenger vs defender [status]". Returns IDs as values.
+    """
+    from discord_bots.models import LadderMatch as _LadderMatch
+    from discord_bots.models import LadderTeam as _LadderTeam
+
+    result = []
+    session: SQLAlchemySession
+    with Session() as session:
+        rows = (
+            session.query(_LadderMatch, Ladder)
+            .join(Ladder, Ladder.id == _LadderMatch.ladder_id)
+            .order_by(_LadderMatch.challenged_at.desc())
+            .limit(50)
+            .all()
+        )
+        cf = current.casefold()
+        for match, ladder in rows:
+            challenger = (
+                session.query(_LadderTeam)
+                .filter(_LadderTeam.id == match.challenger_team_id)
+                .first()
+            )
+            defender = (
+                session.query(_LadderTeam)
+                .filter(_LadderTeam.id == match.defender_team_id)
+                .first()
+            )
+            label = (
+                f"{ladder.name}: "
+                f"{challenger.name if challenger else '?'} vs "
+                f"{defender.name if defender else '?'} "
+                f"[{match.status}]"
+            )
+            label = label[:100]
+            if cf in label.casefold() or cf in match.id:
+                result.append(discord.app_commands.Choice(name=label, value=match.id))
+            if len(result) >= 25:
+                break
+    return result
+
+
 async def ladder_team_autocomplete(interaction: Interaction, current: str):
     """
     Autocomplete team names within the ladder named in the same command.

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -50,6 +50,7 @@ from discord_bots.models import (
     InProgressGame,
     InProgressGameChannel,
     InProgressGamePlayer,
+    Ladder,
     Map,
     MapVote,
     Player,
@@ -1968,6 +1969,23 @@ async def rotation_autocomplete(interaction: Interaction, current: str):
                         discord.app_commands.Choice(
                             name=rotation.name, value=rotation.name
                         )
+                    )
+    return result
+
+
+async def ladder_autocomplete(interaction: Interaction, current: str):
+    result = []
+    session: SQLAlchemySession
+    with Session() as session:
+        ladders: list[Ladder] | None = (
+            session.query(Ladder).order_by(Ladder.name).limit(25).all()
+        )
+        if ladders:
+            current_casefold = current.casefold()
+            for ladder in ladders:
+                if current_casefold in ladder.name.casefold():
+                    result.append(
+                        discord.app_commands.Choice(name=ladder.name, value=ladder.name)
                     )
     return result
 

--- a/discord_bots/utils.py
+++ b/discord_bots/utils.py
@@ -51,6 +51,7 @@ from discord_bots.models import (
     InProgressGameChannel,
     InProgressGamePlayer,
     Ladder,
+    LadderTeam,
     Map,
     MapVote,
     Player,
@@ -1987,6 +1988,38 @@ async def ladder_autocomplete(interaction: Interaction, current: str):
                     result.append(
                         discord.app_commands.Choice(name=ladder.name, value=ladder.name)
                     )
+    return result
+
+
+async def ladder_team_autocomplete(interaction: Interaction, current: str):
+    """
+    Autocomplete team names within the ladder named in the same command.
+    Reads the `ladder` argument from interaction.namespace.
+    """
+    ladder_name = getattr(interaction.namespace, "ladder", None)
+    if not ladder_name:
+        return []
+    result = []
+    session: SQLAlchemySession
+    with Session() as session:
+        ladder_row: Ladder | None = (
+            session.query(Ladder).filter(Ladder.name == ladder_name).first()
+        )
+        if not ladder_row:
+            return []
+        teams: list[LadderTeam] = (
+            session.query(LadderTeam)
+            .filter(LadderTeam.ladder_id == ladder_row.id)
+            .order_by(LadderTeam.name)
+            .limit(25)
+            .all()
+        )
+        current_casefold = current.casefold()
+        for team in teams:
+            if current_casefold in team.name.casefold():
+                result.append(
+                    discord.app_commands.Choice(name=team.name, value=team.name)
+                )
     return result
 
 

--- a/docs/ladder-plan.md
+++ b/docs/ladder-plan.md
@@ -251,10 +251,10 @@ New cog `discord_bots/cogs/ladder.py` (style mirrors `cogs/admin.py` and `cogs/i
 | `/ladder team transfer <ladder> <player>` | Captain-only; gives captaincy to another rostered player. |
 | `/ladder team disband <ladder>` | Captain-only. Releases roster. **Blocked while team has an in-flight match.** |
 | `/ladder challenge <ladder> <opponent_team>` | Challenger captain. |
-| `/ladder accept <ladder> <match_id>` | Defender captain. Maps roll here. |
-| `/ladder decline <ladder> <match_id>` | Defender captain. |
-| `/ladder cancel <ladder> <match_id>` | Challenger captain (only while `pending`). |
-| `/ladder report <ladder> <match_id>` | Either captain. Opens a modal with one row per map to enter scores. |
+| `/ladder accept <ladder>` | Defender captain. Maps roll here. (Match implicit — at most 1 in-flight per team.) |
+| `/ladder decline <ladder>` | Defender captain. |
+| `/ladder cancel <ladder>` | Challenger captain (only while `pending`). |
+| `/ladder report <ladder>` | Either captain. Opens a modal with one row per map to enter scores. |
 
 ### Read-only
 
@@ -264,8 +264,7 @@ New cog `discord_bots/cogs/ladder.py` (style mirrors `cogs/admin.py` and `cogs/i
 | `/ladder rankings <ladder>` | Current standings (also pinned in leaderboard channel). |
 | `/ladder team info <ladder> <team>` | Roster, captain, record, current position, in-flight matches. |
 | `/ladder team list <ladder>` | All teams in a ladder. |
-| `/ladder match info <ladder> <match_id>` | Match details, per-map scores. |
-| `/ladder matches <ladder> [team]` | Recent matches, optionally filtered by team. |
+| `/ladder matchinfo <match_id>` | Match details, per-map scores (autocomplete on match_id). |
 
 ---
 
@@ -320,8 +319,8 @@ Pattern mirrors `discord_bots/cogs/in_progress_game.py:202`.
 ## Permissions
 
 - Admin commands: `is_admin_app_command` (existing).
-- Captain commands: new check `is_team_captain_for_ladder` (queries `LadderTeam.captain_id` against `interaction.user.id` and the ladder named in the command).
-- All other ladder commands: any rostered player on the team. New check `is_team_member_for_ladder`.
+- Captain commands: an inline check inside each command compares `LadderTeam.captain_id` against `interaction.user.id` for the ladder named in the command. (No standalone decorator — kept inline because the lookup needs the ladder argument.)
+- Other player-facing commands look up the caller's team via `LadderTeamPlayer` and gate on roster membership inline.
 
 All ladder commands gate channel via a new check `is_ladder_channel` (uses `Config.ladder_channel_id`). Mirrors `is_command_or_captain_channel` from the captain-pick rollout.
 

--- a/docs/ladder-plan.md
+++ b/docs/ladder-plan.md
@@ -1,0 +1,370 @@
+# Ladder — Implementation Plan
+
+## Overview
+
+Add a TeamWarfareLeague-style challenge ladder. Players form named teams; teams challenge other teams; the winning challenger moves above the defeated team in the rankings. Loss or draw: no movement. The ladder tracks W/L/D records, runs matches over multiple maps drawn from a configured rotation, and surfaces results in dedicated leaderboard and history channels.
+
+The ladder is fully isolated from the existing queue / TrueSkill / economy / raffle / captain-pick systems. Ladder games never write to `FinishedGame`; they live in their own tables.
+
+Multiple ladders can run concurrently. Every command takes an explicit ladder name.
+
+---
+
+## Confirmed decisions
+
+| # | Decision |
+|---|---|
+| 1 | Team join flow is **invite-only** — captain invites, invitee accepts. |
+| 2 | Default **challenge distance** is `3`, configurable per-ladder (`max_challenge_distance`). |
+| 3 | A team may have at most **1 in-flight match** (pending or accepted-but-not-completed, both directions combined). |
+| 4 | Result reporting is **single-report**: either captain submits all map scores in one modal, then admins can edit afterward. |
+| 5 | Commands always require an explicit **ladder name** argument. |
+| 6 | A player can be on **multiple ladders** (one team per ladder). |
+| 7 | `max_team_size` is a hard roster cap. **Everyone rostered plays**; teams must have a full roster to challenge or accept. |
+
+### Other defaults applied
+
+- Map selection at accept-time uses `random.sample` (no duplicates within a single match) unless the rotation has fewer maps than `maps_per_match`, in which case duplicates are allowed (`random.choices`) and a warning is posted to the history channel.
+- A team starts at the bottom of the ladder when created. The bottom is `max(position) + 1`, or `1` if the ladder is empty.
+- The challenger may only challenge teams **strictly above** them, within `max_challenge_distance` positions.
+- **No auto-forfeit.** A team can drop below roster cap (player leaves, captain kicks) while a match is in-flight; the match stays open and the team is expected to fill the roster again before playing. Admins have `/ladder admin forceendmatch` to resolve stuck matches.
+- A team **cannot disband while it has an in-flight match**. The captain must cancel a pending challenge first, or play / forfeit the match (admin) before disbanding.
+- **Position rule on a challenger win**: the challenger inserts **immediately above** the defender. The defender drops by exactly 1. Any teams between them in the old order also shift down by 1 to fill the gap left by the challenger. The challenger's old slot is closed up, not preserved.
+  - Example: positions `... B=2, X=3, Y=4, A=5 ...`. A challenges B and wins. New positions: `... A=2, B=3, X=4, Y=5 ...`.
+- `maps_per_match` is capped at **5**, to fit a single Discord modal for reporting (modals support max 5 components).
+
+---
+
+## Data model
+
+All tables are new. No changes to existing tables. SQLAlchemy models go in `discord_bots/models.py`; one alembic migration creates all of them.
+
+### `Ladder`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `name` | str | unique |
+| `rotation_id` | FK `rotation.id` | reuses existing `Rotation` |
+| `maps_per_match` | int | 1..5 (capped to fit modal); e.g. 3, 5 |
+| `max_team_size` | int | hard roster cap; required to challenge/accept |
+| `max_challenge_distance` | int | default 3 |
+| `max_in_flight_per_team` | int | default 1 |
+| `leaderboard_channel_id` | BigInt nullable | per-ladder; not env-config |
+| `leaderboard_message_id` | BigInt nullable | the single edited message |
+| `history_channel_id` | BigInt nullable | per-ladder |
+| `is_active` | bool | soft-disable without delete |
+| `created_at` | datetime | |
+
+### `LadderTeam`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `ladder_id` | FK `ladder.id` | |
+| `name` | str | unique within ladder |
+| `captain_id` | FK `player.id` | |
+| `position` | int | 1 = top of ladder; unique within ladder |
+| `wins` | int | match-level (not map-level) |
+| `losses` | int | |
+| `draws` | int | |
+| `created_at` | datetime | |
+
+Unique on `(ladder_id, name)` and `(ladder_id, position)`.
+
+### `LadderTeamPlayer`
+
+Roster junction table.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `team_id` | FK `ladder_team.id` | |
+| `player_id` | FK `player.id` | |
+| `joined_at` | datetime | |
+
+Unique on `(team_id, player_id)`. Application-level constraint: a player has at most one team per ladder (enforced via query check; not a DB constraint since it spans tables).
+
+### `LadderTeamInvite`
+
+Pending captain-issued invites.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `team_id` | FK `ladder_team.id` | |
+| `player_id` | FK `player.id` | |
+| `invited_by_id` | FK `player.id` | the captain at invite-time |
+| `created_at` | datetime | |
+| `expires_at` | datetime nullable | optional auto-expire (TBD) |
+
+Unique on `(team_id, player_id)` so a duplicate invite is a no-op.
+
+### `LadderMatch`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `ladder_id` | FK `ladder.id` | |
+| `challenger_team_id` | FK `ladder_team.id` | |
+| `defender_team_id` | FK `ladder_team.id` | |
+| `status` | enum string | `pending`, `accepted`, `completed`, `cancelled` |
+| `winner_team_id` | FK `ladder_team.id` nullable | null on draw / pre-completion |
+| `challenger_map_wins` | int | denormalized map-win count |
+| `defender_map_wins` | int | denormalized map-win count |
+| `challenger_position_at_challenge` | int | snapshot for audit |
+| `defender_position_at_challenge` | int | snapshot for audit |
+| `challenged_at` | datetime | |
+| `accepted_at` | datetime nullable | |
+| `completed_at` | datetime nullable | |
+
+### `LadderMatchGame`
+
+One row per map in a match. Created at accept-time.
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | str (uuid) PK | |
+| `match_id` | FK `ladder_match.id` | |
+| `ordinal` | int | 1..maps_per_match |
+| `map_id` | FK `map.id` | |
+| `challenger_score` | int nullable | reported score |
+| `defender_score` | int nullable | reported score |
+| `winner_team` | int nullable | 0 = challenger, 1 = defender, -1 = draw |
+| `reported_at` | datetime nullable | |
+| `reported_by_id` | FK `player.id` nullable | the captain who reported |
+
+Unique on `(match_id, ordinal)`.
+
+---
+
+## Match lifecycle
+
+```
+[challenge] -> pending -> [accept]                  -> accepted -> [report] -> completed
+                       -> [defender decline]        -> cancelled
+                       -> [challenger cancel]       -> cancelled
+                       -> [admin cancelmatch]       -> cancelled
+                                                       accepted -> [admin forceendmatch] -> completed
+                                                       accepted -> [admin cancelmatch]   -> cancelled
+```
+
+### 1. `/ladder challenge`
+
+- Caller is challenger team's captain.
+- Defender must be **above** challenger in `position`, within `max_challenge_distance`.
+- Both teams must have a full roster (`max_team_size` players each).
+- Both teams must have `< max_in_flight_per_team` open matches.
+- Insert `LadderMatch` row (status `pending`); snapshot positions; post a notice to the history channel.
+
+### 2. `/ladder accept`
+
+- Caller is defender team's captain.
+- Insert `maps_per_match` `LadderMatchGame` rows. Maps are picked via `random.sample(rotation_maps, k=maps_per_match)`. If the rotation has fewer maps than `maps_per_match`, allow duplicates (`random.choices`).
+- Status -> `accepted`, `accepted_at` = now.
+- Post embed to history channel: "Match started: \<challenger\> vs \<defender\>, maps: \<list\>".
+
+### 3. `/ladder decline` and `/ladder cancel`
+
+- `decline`: defender captain rejects a pending challenge -> status `cancelled`.
+- `cancel`: challenger captain rescinds their own pending challenge -> status `cancelled`.
+- Neither path runs once a match is `accepted`. After accept, only admin tooling can revoke.
+
+### 4. `/ladder report`
+
+Reporting is **one command, one modal, all maps at once** — to keep UX simple.
+
+- Either captain runs `/ladder report <ladder> <match_id>`.
+- The bot opens a modal titled `Report match: <challenger> vs <defender>`. The modal has one text input per map (up to 5), each labeled with the map name and accepting a score in `our-their` form, e.g. `3-1`. Pre-filled with any prior values so the same command can be used to amend.
+- On submit:
+  - Parse each row; reject the whole submission if any row is malformed.
+  - Compute `winner_team` per game (higher score wins; equal -> draw).
+  - Update all `LadderMatchGame` rows (`challenger_score`, `defender_score`, `winner_team`, `reported_at`, `reported_by_id`).
+  - Finalize the match (step 5 below).
+- Admins can use `/ladder admin editmatch <match_id>` which opens the same modal pre-populated, allowing post-hoc corrections. Re-submission re-runs finalization.
+
+### 5. Match finalization (internal)
+
+- Compute `challenger_map_wins` and `defender_map_wins` from `LadderMatchGame.winner_team`.
+- Determine match `winner_team_id`:
+  - challenger map wins > defender map wins -> challenger wins
+  - defender map wins > challenger map wins -> defender wins
+  - equal -> draw (no `winner_team_id`)
+- Update team records: winner `wins += 1`, loser `losses += 1`, draws `draws += 1` if applicable.
+- **Position update** (only if challenger won AND `challenger.position > defender.position`):
+  - Capture `old_defender_pos = defender.position`, `old_challenger_pos = challenger.position`.
+  - In one transaction: `UPDATE ladder_team SET position = position + 1 WHERE ladder_id = ? AND position >= old_defender_pos AND position < old_challenger_pos`.
+  - Then: `UPDATE ladder_team SET position = old_defender_pos WHERE id = challenger.id`.
+  - Net effect: defender drops by 1; everyone strictly between them also drops by 1; challenger lands at the defender's old position; challenger's old slot is closed up.
+- Status -> `completed`, `completed_at` = now.
+- Post match summary embed to history channel (with the position changes spelled out).
+- Refresh leaderboard message.
+
+### 6. Roster shortfalls and stuck matches
+
+We do **not** auto-forfeit. A team that drops below `max_team_size` mid-match is expected to refill via captain invite. The match remains in `accepted` status until reported.
+
+Admin escape hatches:
+
+- `/ladder admin forceendmatch <match_id> <winner: challenger|defender|draw>` — finalizes the match in the named team's favor (or as a draw). Same finalization path as a normal report; updates records, applies the position rule, posts to history. Use when a team has gone inactive or refuses to play.
+- `/ladder admin cancelmatch <match_id>` — sets status `cancelled` with no record changes. Use when a match should be voided entirely.
+
+A team **cannot disband** while it has an in-flight match. The captain must:
+- cancel the match (if `pending`), or
+- play and report the match, or
+- ask an admin to `forceendmatch` or `cancelmatch` first.
+
+---
+
+## Commands
+
+New cog `discord_bots/cogs/ladder.py` (style mirrors `cogs/admin.py` and `cogs/in_progress_game.py`). Top-level group `/ladder` with subgroups `admin`, `team`. All commands use `is_command_or_captain_channel` for channel gating; admin commands stack `is_admin_app_command`.
+
+### Admin
+
+| Command | Description |
+|---|---|
+| `/ladder admin create <name> <rotation> <maps_per_match> <max_team_size>` | Create a new ladder. |
+| `/ladder admin delete <name>` | Delete a ladder (cascades teams/matches). |
+| `/ladder admin setchannels <ladder> <leaderboard_channel> <history_channel>` | Set per-ladder channels. |
+| `/ladder admin setmapspermatch <ladder> <value>` | Edit `maps_per_match` (1..5). |
+| `/ladder admin setmaxteamsize <ladder> <value>` | Edit `max_team_size`. |
+| `/ladder admin setchallengedistance <ladder> <value>` | Edit `max_challenge_distance`. |
+| `/ladder admin setactive <ladder> <value>` | Toggle `is_active` (write-block when false). |
+| `/ladder admin editmatch <match_id>` | Open the report modal pre-populated with current scores; re-runs finalization on submit. |
+| `/ladder admin forceendmatch <match_id> <winner: challenger\|defender\|draw>` | Finalize a stuck match in a team's favor (or draw). Applies records + position rule. |
+| `/ladder admin cancelmatch <match_id>` | Void a match entirely; no record changes. |
+| `/ladder admin forceadjust <ladder> <team_name> <new_position>` | Manually move a team in the rankings (rest shift to fill / make room). |
+| `/ladder admin removeteam <ladder> <team_name>` | Force-disband a team (admin); ranks compact. Cancels any in-flight match. |
+
+### Captain / player
+
+| Command | Description |
+|---|---|
+| `/ladder team create <ladder> <team_name>` | Caller becomes captain; team starts at the bottom. |
+| `/ladder team invite <ladder> <player>` | Captain-only. Creates a `LadderTeamInvite`. |
+| `/ladder team uninvite <ladder> <player>` | Captain-only. Revokes a pending invite. |
+| `/ladder team accept <ladder> <team_name>` | Invitee accepts an outstanding invite. Enforces roster cap and one-team-per-ladder. |
+| `/ladder team decline <ladder> <team_name>` | Invitee declines. |
+| `/ladder team leave <ladder>` | Player removes themselves. If captain leaves, must `transfer` first. |
+| `/ladder team kick <ladder> <player>` | Captain-only. |
+| `/ladder team transfer <ladder> <player>` | Captain-only; gives captaincy to another rostered player. |
+| `/ladder team disband <ladder>` | Captain-only. Releases roster. **Blocked while team has an in-flight match.** |
+| `/ladder challenge <ladder> <opponent_team>` | Challenger captain. |
+| `/ladder accept <ladder> <match_id>` | Defender captain. Maps roll here. |
+| `/ladder decline <ladder> <match_id>` | Defender captain. |
+| `/ladder cancel <ladder> <match_id>` | Challenger captain (only while `pending`). |
+| `/ladder report <ladder> <match_id>` | Either captain. Opens a modal with one row per map to enter scores. |
+
+### Read-only
+
+| Command | Description |
+|---|---|
+| `/ladder list` | All ladders with summary. |
+| `/ladder rankings <ladder>` | Current standings (also pinned in leaderboard channel). |
+| `/ladder team info <ladder> <team>` | Roster, captain, record, current position, in-flight matches. |
+| `/ladder team list <ladder>` | All teams in a ladder. |
+| `/ladder match info <ladder> <match_id>` | Match details, per-map scores. |
+| `/ladder matches <ladder> [team]` | Recent matches, optionally filtered by team. |
+
+---
+
+## Channels
+
+There are **three** kinds of ladder-related channels:
+
+1. **Ladder command channel** (single, server-wide) — where `/ladder ...` commands are run. Mirrors the captain-channel pattern (`Config.captain_channel_id`). Stored on the existing singleton `Config` table as a new nullable `ladder_channel_id` column. Set via a new admin command `/config ladderchannel <#channel>`.
+2. **Leaderboard channel** (per-ladder) — bot-edited single-message rankings.
+3. **History channel** (per-ladder) — bot posts an embed per lifecycle event.
+
+Leaderboard + history channel IDs live on the `Ladder` row (not env vars), set via `/ladder admin setchannels`. If unset, those features are no-ops. The ladder command channel is global because all ladders share the same lobby for issuing commands.
+
+### Leaderboard channel
+
+Single bot-edited message, pattern from `discord_bots/utils.py:1595`. Refreshed on:
+- match completion
+- team create / disband / forceadjust
+- ladder config change
+- challenge issued / accepted / cancelled (so the in-flight annotation stays current)
+
+Layout (embed):
+
+```
+Ladder: <name>          maps/match: 3   roster: 8   challenge range: 3
+-----------------------------------------------------------
+1.  Team Alpha                        12-3-1
+2.  Crimson Vipers                     9-4-0     [challenged by Echo Squad]
+3.  Echo Squad                         8-5-2     [challenging Crimson Vipers]
+4.  Northwind                          7-6-0
+...
+```
+
+In-flight annotations:
+- A team that has issued a pending challenge: `[challenging <opponent>]`.
+- A team that has received a pending challenge: `[challenged by <opponent>]`.
+- Both teams in an accepted match: `[challenge accepted vs <opponent>]` (same string on both sides).
+
+### History channel
+
+A new embed posted on each lifecycle event:
+- **Challenge issued** (pending) — challenger, defender, snapshot positions.
+- **Match accepted** — with rolled map list.
+- **Match cancelled** — by whom (decline / cancel / admin).
+- **Match completed** — final per-map scores, match winner, before/after positions for both teams.
+- **Position adjustment** — admin `forceadjust` posts a record.
+
+Pattern mirrors `discord_bots/cogs/in_progress_game.py:202`.
+
+---
+
+## Permissions
+
+- Admin commands: `is_admin_app_command` (existing).
+- Captain commands: new check `is_team_captain_for_ladder` (queries `LadderTeam.captain_id` against `interaction.user.id` and the ladder named in the command).
+- All other ladder commands: any rostered player on the team. New check `is_team_member_for_ladder`.
+
+All ladder commands gate channel via a new check `is_ladder_channel` (uses `Config.ladder_channel_id`). Mirrors `is_command_or_captain_channel` from the captain-pick rollout.
+
+---
+
+## Isolation from existing systems
+
+- No writes to `FinishedGame`, `FinishedGamePlayer`, `Player.rated_trueskill_*`, `PlayerCategoryTrueskill`, `Queue`, `InProgressGame`, economy, raffle.
+- Ladder uses its own `LadderMatch` / `LadderMatchGame` history.
+- Ladder reuses read-only: `Player`, `Map`, `Rotation`, `RotationMap`. No schema changes.
+- Existing leaderboard (`LEADERBOARD_CHANNEL`) and game history (`GAME_HISTORY_CHANNEL`) are untouched. Ladder posts to its own per-ladder channels.
+
+---
+
+## Migration plan
+
+Single alembic migration creating all six new tables (`ladder`, `ladder_team`, `ladder_team_player`, `ladder_team_invite`, `ladder_match`, `ladder_match_game`). Use `batch_op` for SQLite compatibility; follow conventions in `alembic/versions/20250607184820_7d5d0da1c412_add_queue_position_model.py`.
+
+---
+
+## Phased delivery
+
+Each phase is a standalone, reviewable commit on `feat/ladder`.
+
+| Phase | Scope | Verifies |
+|---|---|---|
+| 1 | `Config.ladder_channel_id` column, `/config ladderchannel`, `is_ladder_channel` check, all model tables + migration, admin scaffolding (`/ladder admin create|delete|list|setchannels|setconfig`) | Schema is correct; admins can configure the ladder channel and spin up a ladder. |
+| 2 | Team management (`/ladder team create|invite|uninvite|accept|decline|leave|kick|transfer|disband|info|list`) | Rosters, invites, captaincy work end-to-end with no matches. |
+| 3 | Challenges + match start (`/ladder challenge|accept|decline|cancel`, map rolling, history-channel post on accept, leaderboard in-flight annotations) | Full challenge flow up to "match in progress". |
+| 4 | Result reporting + ranking (`/ladder report` modal, position update, W/L, leaderboard refresh; admin `editmatch|forceendmatch|cancelmatch|forceadjust|removeteam`) | Full end-to-end ladder. |
+
+---
+
+## Resolved questions
+
+1. **Disband / roster shortfall**: no auto-forfeit. Match stays open until reported; admins have `/ladder admin forceendmatch` and `/ladder admin cancelmatch`. A team cannot disband while it has an in-flight match.
+2. **Invite expiry**: invites have **no expiration**. They live until accepted, declined, or revoked by the captain (`/ladder team uninvite` — added below).
+3. **Ladder channel scope**: **dedicated ladder channel**. New `Config.ladder_channel_id` column + `/config ladderchannel` admin command. New check `is_ladder_channel` gates all `/ladder ...` commands.
+4. **Leaderboard refresh**: refresh on every relevant event (match completion, challenge issued/accepted/cancelled, team mutations, config change). Matches are infrequent, so chattiness is not a concern.
+5. **In-flight annotations on leaderboard**: yes, show `[challenging X]` / `[challenged by Y]` / `[match in progress vs Z]` next to teams. Also recorded in history channel.
+6. **Map duplication when rotation < maps_per_match**: allow duplicates via `random.choices`; post a warning to the history channel.
+7. **`Ladder.is_active = false`**: block all writes (challenge, accept, report, team mutations) but allow reads (rankings, info, list).
+
+A small additional command added during this round:
+
+- `/ladder team uninvite <ladder> <player>` — captain-only; revokes an outstanding invite.


### PR DESCRIPTION
## Summary
- Adds a TWL-style challenge ladder: teams form rosters, challenge teams above them, winner moves up by inserting immediately above the loser (loser drops by one).
- Fully isolated from queues / TrueSkill / economy / raffle / captain-pick — ladder games never write to FinishedGame; uses six new tables (ladder, ladder_team, ladder_team_player, ladder_team_invite, ladder_match, ladder_match_game).
- Dedicated ladder command channel via new \`Config.ladder_channel_id\` + \`/config setladderchannel\` + \`is_ladder_channel\` check. Per-ladder leaderboard and history channels (\`/ladder admin setchannels\`).
- 31 slash commands: 12 admin, 11 team, 4 challenge/accept/decline/cancel, 1 report, 3 read-only.

Design doc lives at \`docs/ladder-plan.md\`.

## Phases (one commit each)
1. \`737f701\` Schema + admin scaffolding
2. \`e1c120c\` Team management (invite/accept/leave/kick/transfer/disband/etc.)
3. \`10116b8\` Challenges, accept/decline/cancel, map rolling, leaderboard refresh w/ in-flight annotations
4. \`aa4006f\` Result reporting (modal-based), match finalization w/ position rule, admin overrides

## Confirmed design choices
- Invite-only team joining (captain invites, invitee accepts).
- Default \`max_challenge_distance\` = 3, configurable per-ladder.
- Max **1** in-flight match per team.
- Single-report scoring (any captain reports all maps in one modal); admins can edit afterward.
- Ladder name is always required on commands.
- Players can be on multiple ladders (one team per ladder).
- \`max_team_size\` is a hard roster cap; teams must be full to challenge or accept.
- \`maps_per_match\` capped at 5 (fits a single Discord modal).
- Position rule: challenger inserts immediately above defender; teams between shift down by 1; challenger's old slot closes up.
- No auto-forfeit on roster shortfall; admin tooling (\`forceendmatch\`, \`cancelmatch\`) handles stuck matches.
- Disband is blocked while a team has an in-flight match.

## Test plan
- [ ] Run \`alembic upgrade head\` against the production DB and confirm the new tables / \`config.ladder_channel_id\` column appear.
- [ ] \`/config setladderchannel #ladder-lobby\`; verify \`/ladder ...\` commands are gated to that channel.
- [ ] \`/ladder admin create\` a ladder against an existing rotation; check \`/ladder list\`.
- [ ] \`/ladder admin setchannels\` for leaderboard and history channels; verify the leaderboard message posts and is then edited on subsequent events.
- [ ] Create two teams, fill rosters via invite/accept, then issue \`/ladder challenge\` and \`/ladder accept\` — confirm map list posts to history.
- [ ] Run \`/ladder report\`; confirm modal opens with one row per map; submit invalid scores; submit valid; verify history embed and leaderboard update.
- [ ] Verify position rule with three+ teams (challenger from below beating a team above; teams between shift down by 1, not swap).
- [ ] \`/ladder admin editmatch\` to change a completed match's outcome; verify W/L and position both undo and re-apply correctly.
- [ ] \`/ladder admin forceendmatch\`, \`cancelmatch\`, \`forceadjust\`, \`removeteam\` smoke tests.
- [ ] Try to disband a team while it has an in-flight match — should be blocked.
- [ ] Set \`is_active = false\`; verify writes are blocked, reads still work.
- [ ] Confirm rotation with fewer maps than \`maps_per_match\` triggers the \`random.choices\` fallback and posts a warning to history.

## Caveats
- Not end-to-end-tested in Discord. Smoke tests covered model imports, alembic SQL generation, and the in-memory position-swap + undo logic, but the slash commands, modal, autocompletes, and channel-message editing have not been exercised in a live server.
- The pre-existing SQLite \`alembic upgrade head\` failure on the older \`NOW()\` migration is unrelated and unchanged.
- \`/ladder matches <ladder> [team]\` (recent-matches list) was in the original plan but dropped — the history channel and \`/ladder matchinfo <match_id>\` cover the need. Easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)